### PR TITLE
In 1.9, docker inspect includes a :ro or :rw for VolumesFrom. This co…

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -24,8 +24,8 @@ EOT
 function get_nginx_proxy_cid {
 	# Look for a NGINX_VERSION environment variable in containers that we have mount volumes from.
     for cid in $(docker inspect --format '{{ range $volume := .HostConfig.VolumesFrom }}{{ $volume }} {{ end}}' $CONTAINER_ID 2>/dev/null); do
-		if [[ -n "$(docker exec -t $cid sh -c 'echo -n $NGINX_VERSION')" ]]; then
-			export NGINX_PROXY_CID=$cid
+		if [[ -n "$(docker exec -t ${cid%:*} sh -c 'echo -n $NGINX_VERSION')" ]]; then
+			export NGINX_PROXY_CID=${cid%:*}
 			break
 		fi
 	done


### PR DESCRIPTION
…mmit lops off the colon and everything after it. It does not affect the old format

Fixes https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/1