### PR TITLE
Disable basic auth for letsencrypt challenge

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,4 +1,5 @@
 location /.well-known/ {
+    auth_basic off;
     root /usr/share/nginx/html;
     try_files $uri =404;
 }


### PR DESCRIPTION
When using basic auth https://github.com/jwilder/nginx-proxy#basic-authentication-support,
letsencrypt can't verify the challenge and certificate creation fails. basic auth needs to be switched off for the .well-known directory



