### PR TITLE
fix "Invalid character in DNS name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ For example
 
 ```bash
 $ docker run -d \
-    -e VIRTUAL_HOST="foo.bar.com,bar.com" \
-    -e LETSENCRYPT_HOST="foo.bar.com,bar.com" \
+    -e VIRTUAL_HOST=foo.bar.com,bar.com \
+    -e LETSENCRYPT_HOST=foo.bar.com,bar.com \
     -e LETSENCRYPT_EMAIL="foo@bar.com" ...
 ```
 ##### Automatic certificate renewal


### PR DESCRIPTION
the quotes are raising a "Invalid character in DNS name";

it took me some time to realise, so I hope noe more people will lose the same time.