### PR TITLE
Use `rw` in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example of use:
 ```bash
 $ docker run -d -p 80:80 -p 443:443 \
     --name nginx-proxy \
-    -v /path/to/certs:/etc/nginx/certs:ro \
+    -v /path/to/certs:/etc/nginx/certs:rw \
     -v /etc/nginx/vhost.d \
     -v /usr/share/nginx/html \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
@@ -69,7 +69,7 @@ $ docker run -d -p 80:80 -p 443:443 \
     -v /etc/nginx/conf.d  \
     -v /etc/nginx/vhost.d \
     -v /usr/share/nginx/html \
-    -v /path/to/certs:/etc/nginx/certs:ro \
+    -v /path/to/certs:/etc/nginx/certs:rw \
     nginx
 ```
 


### PR DESCRIPTION
Hey, just tried your examples in the README and of course I just copy/pasted things :)
`/etc/nginx/certs` needs to be mounted `:rw` so `jrcs/letsencrypt-nginx-proxy-companion` can save the certs :)