### PR TITLE
break in location in case the upstream is protected

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -2,4 +2,5 @@ location /.well-known/acme-challenge/ {
     auth_basic off;
     root /usr/share/nginx/html;
     try_files $uri =404;
+    break;
 }


### PR DESCRIPTION
Add a break into the letsencrypt block so that no more rules are executed otherwise if you have a block like...

    ## Start of configuration add by letsencrypt container
    location /.well-known/acme-challenge/ {
        auth_basic off;
        root /usr/share/nginx/html;
        try_files $uri =404;
    }
    ## End of configuration add by letsencrypt container
    
    if (!-f /code/home/cookies/$cookie_AUTH_COOKIE) {
        rewrite ^ https://auth.example.org break;
    }

Then lets encrypt never manages to verify the domain as the request gets re-written to the authentication URL and you get messages like...

    Creating/renewal blah.example.org certificates... (blah.example.org)
    2016-05-06 13:02:36,270:INFO:simp_le:1211: Generating new account key
    2016-05-06 13:02:36,822:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): acme-v01.api.letsencrypt.org
    2016-05-06 13:02:37,195:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): acme-v01.api.letsencrypt.org
    2016-05-06 13:02:37,620:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): acme-v01.api.letsencrypt.org
    2016-05-06 13:02:38,352:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): letsencrypt.org
    2016-05-06 13:02:41,747:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): acme-v01.api.letsencrypt.org
    2016-05-06 13:02:42,495:INFO:requests.packages.urllib3.connectionpool:756: Starting new HTTPS connection (1): acme-v01.api.letsencrypt.org
    2016-05-06 13:02:43,456:INFO:requests.packages.urllib3.connectionpool:207: Starting new HTTP connection (1): blah.example.org
    2016-05-06 13:02:44,466:ERROR:acme.challenges:256: Unable to reach http://blah.example.org/.well-known/acme-challenge/tOe23Vz3BwEnXIHX4SP87hzUimiJkg68wx0HAMp_um0: HTTPConnectionPool(host='blah.example.org', port=80): Max retries exceeded with url: /.well-known/acme-challenge/tOe23Vz3BwEnXIHX4SP87hzUimiJkg68wx0HAMp_um0 (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7f04ee277150>: Failed to establish a new connection: [Errno 113] Host is unreachable',))
`