### PR TITLE
enable public access to validation endpoints

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,5 +1,5 @@
 location /.well-known/acme-challenge/ {
-    auth_basic off;
+    allow all;
     root /usr/share/nginx/html;
     try_files $uri =404;
     break;


### PR DESCRIPTION
Enable public access to validation endpoints despite existing IP whitelisting or basic auth settings. For existing basic auth and IP whitelist setups, the `auth_basic off;` is not sufficient to allow Lets Encrypt to be able to access the container via HTTP.