### PR TITLE
corrected instructions for nginx.tmpl, included local copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ letsencrypt-nginx-proxy-companion is a lightweight companion container for the [
 * Automatically creation of a Strong Diffie-Hellman Group (for having an A+ Rate on the [Qualsys SSL Server Test](https://www.ssllabs.com/ssltest/)).
 * Work with all versions of docker.
 
-***NOTE***: The first time this container is launch it generate a new Diffie-Hellman group file. This process can take several minutes to complete (be patient).
+***NOTE***: The first time this container is launched it generate a new Diffie-Hellman group file. This process can take several minutes to complete (be patient).
 
 #### Usage
 
@@ -53,9 +53,9 @@ You may want to do this to prevent having the docker socket bound to a publicly 
 
 To run nginx proxy as a separate container you'll need:
 
-1) To mount the template file [nginx.tmpl](https://github.com/jwilder/nginx-proxy/blob/master/nginx.tmpl) into the docker-gen container. You can get the latest official [nginx.tmpl](https://github.com/jwilder/nginx-proxy/blob/master/nginx.tmpl) with a command like:
+1) To mount the template file [nginx.tmpl](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/blob/master/nginx.tmpl) into the docker-gen container. This is a modified version of the latest official [nginx.tmpl](https://github.com/jwilder/nginx-proxy/blob/master/nginx.tmpl), to permit LetsEncrypt challenge-response validation, with a command like:
 ```bash
-curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
+curl https://raw.githubusercontent.com/JrCs/docker-letsencrypt-nginx-proxy-companion/master/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
 2) Set the `NGINX_DOCKER_GEN_CONTAINER` environment variable to the name or id of the docker-gen container.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,0 +1,233 @@
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+
+{{ define "upstream" }}
+  {{ if .Address }}
+    {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+    {{ if and .Container.Node.ID .Address.HostPort }}
+      # {{ .Container.Node.Name }}/{{ .Container.Name }}
+      server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+    {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+    {{ else if .Network }}
+      # {{ .Container.Name }}
+      server {{ .Network.IP }}:{{ .Address.Port }};
+    {{ end }}
+  {{ else if .Network }}
+    # {{ .Container.Name }}
+    server {{ .Network.IP }} down;
+  {{ end }}
+{{ end }}
+
+# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+# scheme used to connect to this server
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
+# If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+# Connection header that may have been passed to this server
+map $http_upgrade $proxy_connection {
+  default upgrade;
+  '' close;
+}
+
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+
+access_log off;
+
+{{ if (exists "/etc/nginx/proxy.conf") }}
+include /etc/nginx/proxy.conf;
+{{ else }}
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+{{ end }}
+
+server {
+  server_name _; # This is just an invalid value which will never trigger on a real hostname.
+  listen 80;
+  access_log /var/log/nginx/access.log vhost;
+  return 503;
+}
+
+{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+  server_name _; # This is just an invalid value which will never trigger on a real hostname.
+  listen 443 ssl http2;
+  access_log /var/log/nginx/access.log vhost;
+  return 503;
+
+  ssl_certificate /etc/nginx/certs/default.crt;
+  ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
+{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+
+upstream {{ $host }} {
+{{ range $container := $containers }}
+  {{ $addrLen := len $container.Addresses }}
+
+  {{ range $knownNetwork := $CurrentContainer.Networks }}
+    {{ range $containerNetwork := $container.Networks }}
+      {{ if eq $knownNetwork.Name $containerNetwork.Name }}
+        ## Can be connect with "{{ $containerNetwork.Name }}" network
+
+        {{/* If only 1 port exposed, use that */}}
+        {{ if eq $addrLen 1 }}
+          {{ $address := index $container.Addresses 0 }}
+          {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+        {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+        {{ else }}
+          {{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+          {{ $address := where $container.Addresses "Port" $port | first }}
+          {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+}
+
+{{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
+{{ $default_server := index (dict $host "" $default_host "default_server") $host }}
+
+{{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
+{{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
+
+{{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
+{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
+
+{{/* Get the first cert name defined by containers w/ the same vhost */}}
+{{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
+
+{{/* Get the best matching cert  by name for the vhost. */}}
+{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
+
+{{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
+{{ $vhostCert := replace $vhostCert ".crt" "" -1 }}
+{{ $vhostCert := replace $vhostCert ".key" "" -1 }}
+
+{{/* Use the cert specifid on the container or fallback to the best vhost match */}}
+{{ $cert := (coalesce $certName $vhostCert) }}
+
+{{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+
+{{ if $is_https }}
+
+{{ if eq $https_method "redirect" }}
+server {
+  server_name {{ $host }};
+  listen 80 {{ $default_server }};
+  access_log /var/log/nginx/access.log vhost;
+
+        # pass LE ACME challenge-responses to the local filesystem (if they exist), else pass on to redirect
+        location /.well-known/ {
+         root /usr/share/nginx/html;
+         try_files $uri @proxy_pass;
+        }
+
+  return 301 https://$host$request_uri;
+}
+{{ end }}
+
+server {
+  server_name {{ $host }};
+  listen 443 ssl http2 {{ $default_server }};
+  access_log /var/log/nginx/access.log vhost;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+
+  ssl_prefer_server_ciphers on;
+  ssl_session_timeout 5m;
+  ssl_session_cache shared:SSL:50m;
+
+  ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
+  ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+
+  {{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
+  ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
+  {{ end }}
+
+  add_header Strict-Transport-Security "max-age=31536000";
+
+  {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+  {{ else if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
+
+  location / {
+    proxy_pass {{ trim $proto }}://{{ trim $host }};
+    {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+    auth_basic  "Restricted {{ $host }}";
+    auth_basic_user_file  {{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{ end }}
+                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+                include /etc/nginx/vhost.d/default_location;
+                {{ end }}
+  }
+}
+
+{{ end }}
+
+{{ if or (not $is_https) (eq $https_method "noredirect") }}
+
+server {
+  server_name {{ $host }};
+  listen 80 {{ $default_server }};
+  access_log /var/log/nginx/access.log vhost;
+
+  {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+  {{ else if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
+
+  # pass LE ACME challenge-responses to the local filesystem (if they exist), else pass on to redirect
+  location /.well-known/ {
+      root /usr/share/nginx/html;
+      try_files $uri @proxy_pass;
+  }
+
+  location / {
+    proxy_pass {{ trim $proto }}://{{ trim $host }};
+    {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+    auth_basic  "Restricted {{ $host }}";
+    auth_basic_user_file  {{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{ end }}
+                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+                include /etc/nginx/vhost.d/default_location;
+                {{ end }}
+  }
+}
+
+{{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+  server_name {{ $host }};
+  listen 443 ssl http2 {{ $default_server }};
+  access_log /var/log/nginx/access.log vhost;
+  return 503;
+
+  ssl_certificate /etc/nginx/certs/default.crt;
+  ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
nginx.tmpl requires additional config (from the docker-gen original) to support LetsEncrypt challenge-response. This request amends README.md to change instructions slightly, and includes amended nginx.tmpl as required.