### PR TITLE
Output certificate trust chain for OCSP stapling

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -31,6 +31,10 @@ create_links() {
         create_link "/etc/nginx/certs/$domain".dhparam.pem ./dhparam.pem
         return_code=$(( $return_code & $? ))
     fi
+    if [[ -f "/etc/nginx/certs/$base_domain"/chain.pem ]]; then
+        create_link "/etc/nginx/certs/$domain".chain.crt "./$base_domain"/chain.pem
+        return_code=$(( $return_code & $? ))
+    fi
     return $return_code
 }
 
@@ -98,7 +102,7 @@ update_certs() {
 
         echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
         /usr/bin/simp_le \
-            -f account_key.json -f key.pem -f fullchain.pem -f cert.pem \
+            -f account_key.json -f key.pem -f fullchain.pem -f cert.pem -f chain.pem \
             --tos_sha256 6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221 \
             $params_d_str \
             --email "${!email_varname}" \


### PR DESCRIPTION
Together with jwilder/nginx-proxy#574 this should enable OCSP stapling.