### PR TITLE
Support referencing nginx-gen container indirectly through another environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,7 @@ $ docker run -d \
 
 * `NGINX_PROXY_CONTAINER`- If for some reason you can't use the docker --volumes-from option, you can specify the name or id of the nginx-proxy container with this variable.
 
+* `NGINX_DOCKER_GEN_LINKED_CONTAINER_ENVVAR` - If you are running nginx-gen as a [linked container](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/) and its ID cannot be predetermined, specify the name of the environment variable of the form `<alias>_NAME` that gets set by Docker when linking containers.
+
 #### Examples:
 If you want other examples how to use this container, look at [docker-letsencrypt-nginx-proxy-companion-examples] (https://github.com/fatk/docker-letsencrypt-nginx-proxy-companion-examples).

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -75,7 +75,16 @@ source /app/functions.sh
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_docker_socket
     if [[ -z "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
-        [[ -z "${NGINX_PROXY_CONTAINER:-}" ]] && get_nginx_proxy_cid
+        if [[ ! -z "${NGINX_DOCKER_GEN_LINKED_CONTAINER_ENVVAR:-}" ]]; then
+            # `NGINX_DOCKER_GEN_LINKED_CONTAINER_ENVVAR` is expected to
+            # contain the name of the environment variable of the form
+            # `<alias>_NAME` that gets set by Docker when linking containers.
+            # We need to chop off the `/` prefix to be able to use its
+            # value in Docker Remote API calls.
+            export NGINX_DOCKER_GEN_CONTAINER=$(echo ${!NGINX_DOCKER_GEN_LINKED_CONTAINER_ENVVAR} | sed 's/^\///')
+        else
+            [[ -z "${NGINX_PROXY_CONTAINER:-}" ]] && get_nginx_proxy_cid
+        fi
     fi
     check_writable_directory '/etc/nginx/certs'
     check_writable_directory '/etc/nginx/vhost.d'


### PR DESCRIPTION
### Motivation

I'm running this container alongside nginx-gen in Amazon ECS. The docker-gen container gets assigned a mangled name like "ecs-tws3-24-nginx-gen-aa9cf4babdd593ae5e00", which means I can't simply set `NGINX_DOCKER_GEN_CONTAINER=nginx-gen`.

What I ended up doing is [linking](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/) those containers and having Docker assign and expose a namespaced name as an environment variable like:

```sh
NGINX_GEN_NAME=/ecs-tws3-23-nginx-letsencrypt-a6d9b293fc808bf7fd01/nginx-gen
```

### What this PR does

This PR adds the ability to specify the name of this environment variable instead of directly specifying docker-gen's container ID or name.
