### PR TITLE
Added chain.pem plugin to simp_le call

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -98,7 +98,7 @@ update_certs() {
 
         echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
         /usr/bin/simp_le \
-            -f account_key.json -f key.pem -f fullchain.pem -f cert.pem \
+            -f account_key.json -f key.pem -f chain.pem -f fullchain.pem -f cert.pem \
             --tos_sha256 6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221 \
             $params_d_str \
             --email "${!email_varname}" \


### PR DESCRIPTION
This allows other services which need the CA certificate in a dedicated
file (such as postfix or dovecot) to use the created certificates.