### PR TITLE
Switch to simp_le's acme-0.8 branch before building

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -11,6 +11,7 @@ git -C /src clone https://github.com/kuba/simp_le.git
 
 # Install simp_le in /usr/bin
 cd /src/simp_le
+git checkout acme-0.8
 python ./setup.py install
 
 # Make house cleaning


### PR DESCRIPTION
As discussed in #130, we're currently unable to issue SSL certs with this docker image. It's because simp_le needs to merge pull request [#112](https://github.com/kuba/simp_le/pull/112) and use a more recent version of the acme dependency. 

This is a short-term fix that manually switches to the branch of that pull request during build. This fix should be removed as soon as that pull request is merged, as it will be using a stale branch of the simp_le code. Unfortunately the last commit to simp_le was 8 months ago.