### PR TITLE
workaround #134 / #130

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -7,7 +7,7 @@ apk --update add python py-requests py-setuptools git gcc py-pip musl-dev libffi
 
 # Get Let's Encrypt simp_le client source
 mkdir -p /src
-git -C /src clone https://github.com/kuba/simp_le.git
+git -C /src clone -b acme-0.8 https://github.com/kuba/simp_le.git || git -C /src clone https://github.com/kuba/simp_le.git
 
 # Install simp_le in /usr/bin
 cd /src/simp_le


### PR DESCRIPTION
## Disclaimer

I am perfectly aware that this is a dirty hack, and not good solution. But I think it's way better than the project not working at all.

## The problem

The root cause of the issue is already reported [on simpl_le](https://github.com/kuba/simp_le/issues/118)

It can be fixed by upgrading the client library. There is [a PR](https://github.com/kuba/simp_le/issues/118), but it's not merged yet.

## The workaround

Be cause I need this to work for my own setup, I forked docker-letsencrypt-nginx-proxy-companion to get the "acme-0.8" branch instead of "master" from simp_le

To prevent it from blowing up the day the branch is merged or removed, I added a fallback that gets the master if the branch doesn't exist.

This way, we can get docker-letsencrypt-nginx-proxy-companion back to work until the issue is fixed on simp_le and come back to remove this workaround at this time, and implement one of the better solutions discussed on the issue.