### PR TITLE
[FEATURE] Create SAN certificates only for common domains

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -62,59 +62,83 @@ update_certs() {
         # First domain will be our base domain
         base_domain="${hosts_array_expanded[0]}"
 
-        if [[ "$create_test_certificate" == true ]]; then
-            # Use staging acme end point
-            acme_ca_uri="https://acme-staging.api.letsencrypt.org/directory"
-            if [[ ! -f /etc/nginx/certs/.${base_domain}.test ]]; then
-                # Remove old certificates
-                rm -rf /etc/nginx/certs/${base_domain}
-                for domain in "${!hosts_array}"; do
-                    rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
-                done
-                touch /etc/nginx/certs/.${base_domain}.test
-            fi
-        else
-            acme_ca_uri="$ACME_CA_URI"
-            if [[ -f /etc/nginx/certs/.${base_domain}.test ]]; then
-                # Remove old test certificates
-                rm -rf /etc/nginx/certs/${base_domain}
-                for domain in "${!hosts_array}"; do
-                    rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
-                done
-                rm -f /etc/nginx/certs/.${base_domain}.test
-            fi
-        fi
+        # Identify base_domains
+        declare -a base_domains
+        base_domains+=("$base_domain")
 
-        # Create directory for the first domain
-        mkdir -p /etc/nginx/certs/$base_domain
-        cd /etc/nginx/certs/$base_domain
-
-        for domain in "${!hosts_array}"; do
-            # Add all the domains to certificate
-            params_d_str+=" -d $domain"
-            # Add location configuration for the domain
-            add_location_configuration "$domain" || reload_nginx
+        for domain in "${!hosts_array:1}"; do
+          if [[ $domain == *"$base_domain"* ]]; then
+            echo "$domain contains $base_domain, skipping."
+          else
+            echo "$domain not found in $base_domain. Adding $domain to base_domains."
+            base_domain=$domain
+            base_domains+=("$base_domain")
+          fi
         done
 
-        echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
-        /usr/bin/simp_le \
-            -f account_key.json -f key.pem -f fullchain.pem -f cert.pem \
-            --tos_sha256 6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221 \
-            $params_d_str \
-            --email "${!email_varname}" \
-            --server=$acme_ca_uri \
-            --default_root /usr/share/nginx/html/
+        for base_domain in "${base_domains[@]}"; do
+          echo "Base domain is now $base_domain"
+          if [[ "$create_test_certificate" == true ]]; then
+              # Use staging acme end point
+              acme_ca_uri="https://acme-staging.api.letsencrypt.org/directory"
+              if [[ ! -f /etc/nginx/certs/.${base_domain}.test ]]; then
+                  # Remove old certificates
+                  rm -rf /etc/nginx/certs/${base_domain}
+                  for domain in "${!hosts_array}"; do
+                      rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
+                  done
+                  touch /etc/nginx/certs/.${base_domain}.test
+              fi
+          else
+              acme_ca_uri="$ACME_CA_URI"
+              if [[ -f /etc/nginx/certs/.${base_domain}.test ]]; then
+                  # Remove old test certificates
+                  rm -rf /etc/nginx/certs/${base_domain}
+                  for domain in "${!hosts_array}"; do
+                      rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
+                  done
+                  rm -f /etc/nginx/certs/.${base_domain}.test
+              fi
+          fi
 
-        simp_le_return=$?
+          # Create directory for the first domain
+          mkdir -p /etc/nginx/certs/$base_domain
+          cd /etc/nginx/certs/$base_domain
+          related_domains=()
+          params_d_str=''
 
-        for altnames in ${hosts_array_expanded[@]:1}; do
-            # Remove old CN domain that now are altnames
-            rm -rf /etc/nginx/certs/$altnames
-        done
+          for domain in "${!hosts_array}"; do
+            if [[ $domain == *"$base_domain"* ]]; then
+              # Add all the domains to certificate
+              params_d_str+=" -d $domain"
+              related_domains+=($domain)
+              # Add location configuration for the domain
+              add_location_configuration "$domain" || reload_nginx
+            fi
+          done
 
-        for domain in "${!hosts_array}"; do
-            create_links $base_domain $domain && reload_nginx='true'
-            [[ $simp_le_return -eq 0 ]] && reload_nginx='true'
+          echo "Creating/renewal $base_domain certificates... (${related_domains[*]})"
+          /usr/bin/simp_le \
+              -f account_key.json -f key.pem -f fullchain.pem -f cert.pem \
+              --tos_sha256 6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221 \
+              $params_d_str \
+              --email "${!email_varname}" \
+              --server=$acme_ca_uri \
+              --default_root /usr/share/nginx/html/
+
+          simp_le_return=$?
+
+          for altnames in ${related_domains[@]:1}; do
+              echo "Removing old CN domain for $altnames"
+              # Remove old CN domain that now are altnames
+              rm -rf /etc/nginx/certs/$altnames
+          done
+
+          for domain in "${related_domains[@]}"; do
+              echo "Creating links for $domain related to $base_domain"
+              create_links $base_domain $domain && reload_nginx='true'
+              [[ $simp_le_return -eq 0 ]] && reload_nginx='true'
+          done
         done
     done
 

--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -11,6 +11,7 @@ git -C /src clone https://github.com/kuba/simp_le.git
 
 # Install simp_le in /usr/bin
 cd /src/simp_le
+git checkout acme-0.8
 python ./setup.py install
 
 # Make house cleaning


### PR DESCRIPTION
SAN certificates are now only created if the domain is contained in the base_domain.

For example:
     `LETSENCRYPT_HOST=domain.tld,sub.domain.tld,sub2.domain.tld,newdomain.tld,sub.newdomain.tld`

will create 2 SAN certificates for `domain.tld` and `newdomain.tld`.