### PR TITLE
Update docker API call

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -43,7 +43,7 @@ function docker_api {
     fi
     if [[ $DOCKER_HOST == unix://* ]]; then
         curl_opts+=(--unix-socket ${DOCKER_HOST#unix://})
-        scheme='http:'
+        scheme='http://localhost'
     else
         scheme="http://${DOCKER_HOST#*://}"
     fi


### PR DESCRIPTION
Based on the docker issue (https://github.com/docker/docker/issues/26099) the docker api needs to be called with `localhost` in the URL. With earlier versions of curl this wasn't an issue, starting with curl 7.5 an error is returned. Adding localhost works for newer and older versions of curl.