### PR TITLE
Fix renewals on separate containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To run nginx proxy as a separate container you'll need:
 curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
-2) Set the `NGINX_DOCKER_GEN_CONTAINER` environment variable to the name or id of the docker-gen container.
+2) Set the `NGINX_DOCKER_GEN_CONTAINER` and `NGINX_CONTAINER` environment variable to the name or id of the docker-gen and nginx containers respectively.
 
 Examples:
 
@@ -92,6 +92,7 @@ $ docker run -d \
 $ docker run -d \
     --name nginx-letsencrypt \
     -e "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" \
+    -e "NGINX_CONTAINER=nginx" \
     --volumes-from nginx \
     -v /path/to/certs:/etc/nginx/certs:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ $ docker run -d \
 ```
 Then start any containers to be proxied as described previously.
 
+* If for some reason you can't use the docker --volumes-from option, you can specify the name or id of the nginx container with `NGINX_PROXY_CONTAINER` variable.
+
 #### Let's Encrypt
 
 To use the Let's Encrypt service to automatically create a valid certificate for virtual host(s).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To run nginx proxy as a separate container you'll need:
 curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
-2) Set the `NGINX_DOCKER_GEN_CONTAINER` and `NGINX_CONTAINER` environment variable to the name or id of the docker-gen and nginx containers respectively.
+2) Set the `NGINX_DOCKER_GEN_CONTAINER` environment variable to the name or id of the docker-gen container.
 
 Examples:
 
@@ -92,7 +92,6 @@ $ docker run -d \
 $ docker run -d \
     --name nginx-letsencrypt \
     -e "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" \
-    -e "NGINX_CONTAINER=nginx" \
     --volumes-from nginx \
     -v /path/to/certs:/etc/nginx/certs:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -70,14 +70,9 @@ function docker_kill {
 ## Nginx
 reload_nginx() {
     if [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
-        # Using docker-gen and nginx in separate container
-        echo "Reloading nginx docker-gen (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
+        # Using docker-gen separate container
+        echo "Reloading nginx proxy (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
         docker_kill "$NGINX_DOCKER_GEN_CONTAINER" SIGHUP
-        if [[ -n "${NGINX_CONTAINER:-}" ]]; then
-            # Reloading nginx in case only certificates had been renewed
-            echo "Reloading nginx (using separate container ${NGINX_CONTAINER})..."
-            docker_kill "$NGINX_CONTAINER" SIGHUP
-        fi
     else
         if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
             echo "Reloading nginx proxy..."

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -70,9 +70,14 @@ function docker_kill {
 ## Nginx
 reload_nginx() {
     if [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
-        # Using docker-gen separate container
-        echo "Reloading nginx proxy (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
+        # Using docker-gen and nginx in separate container
+        echo "Reloading nginx docker-gen (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
         docker_kill "$NGINX_DOCKER_GEN_CONTAINER" SIGHUP
+        if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
+            # Reloading nginx in case only certificates had been renewed
+            echo "Reloading nginx (using separate container ${NGINX_PROXY_CONTAINER})..."
+            docker_kill "$NGINX_PROXY_CONTAINER" SIGHUP
+        fi
     else
         if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
             echo "Reloading nginx proxy..."

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -70,9 +70,14 @@ function docker_kill {
 ## Nginx
 reload_nginx() {
     if [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
-        # Using docker-gen separate container
-        echo "Reloading nginx proxy (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
+        # Using docker-gen and nginx in separate container
+        echo "Reloading nginx docker-gen (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
         docker_kill "$NGINX_DOCKER_GEN_CONTAINER" SIGHUP
+        if [[ -n "${NGINX_CONTAINER:-}" ]]; then
+            # Reloading nginx in case only certificates had been renewed
+            echo "Reloading nginx (using separate container ${NGINX_CONTAINER})..."
+            docker_kill "$NGINX_CONTAINER" SIGHUP
+        fi
     else
         if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
             echo "Reloading nginx proxy..."


### PR DESCRIPTION
As described in issue #121 there is a bug when there is no new domains added, and needed to _SIGHUP_ _nginx_ container.
This pull requests automatize this reload in this case scenario.

It could be more optimal and only reload _nginx_ container in case no new domains had been found, but sending _SIGHUP_ to _nginx_ container twice doesn't seem like a big cost. At least for a quick short term solution.