### PR TITLE
Do not generate certs if LETSENCRYPT_HOST is empty

### DIFF
--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -1,11 +1,15 @@
-LETSENCRYPT_CONTAINERS=({{ range $host, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}{{ range $container := $containers }} '{{ printf "%.12s" $container.ID }}' {{ end }}{{ end }})
+LETSENCRYPT_CONTAINERS=({{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}{{ if trim $hosts }}{{ range $container := $containers }} '{{ printf "%.12s" $container.ID }}' {{ end }}{{ end }}{{ end }})
 
 {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
+
+{{ if trim $hosts }}
 
 {{ range $container := $containers }}{{ $cid := printf "%.12s" $container.ID }}
 LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}'{{ $host }}' {{ end }})
 LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
 LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
+{{ end }}
+
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
My need is to ignore the containers which have LETSENCRYPT_HOST environment variable, but it's empty. Currently in this case the following error is displayed every second, in a loop:

    Creating/renewal  certificates... ()
    simp_le: error: argument -d/--vhost: expected one argument
    /app/letsencrypt_service: line 18: 1: missing base_domain argument
    Creating/renewal  certificates... ()
    simp_le: error: argument -d/--vhost: expected one argument
    /app/letsencrypt_service: line 18: 1: missing base_domain argument

I want to start applications via Docker Compose, and pass LETSENCRYPT_HOST variable from the environment, and if the variable is not present when running docker-compose, then I want to not activate Let's Encrypt for this application. 

Example docker-compose.yml:

    version: '2'

    services:
 
        main:
            image: puffinrocks/ghost:latest
            ports: 
                - 2368
            environment:
                - VIRTUAL_HOST
                - VIRTUAL_PORT=2368
                - LETSENCRYPT_HOST
                - LETSENCRYPT_EMAIL
                - LETSENCRYPT_TEST
            volumes: 
                - main_data:/var/lib/ghost
            tmpfs:
                - /run
                - /tmp

    volumes:
        main_data:

I don't know the template syntax very well, hence my patch is sort of naive. I am open for suggestions / pointers on how to improve it.