### PR TITLE
Set /.well-known/acme-challenge nginx location path as prefix string

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,4 +1,4 @@
-location /.well-known/acme-challenge/ {
+location ^~ /.well-known/acme-challenge/ {
     allow all;
     root /usr/share/nginx/html;
     try_files $uri =404;


### PR DESCRIPTION
In nginx.tmpl, when you want to renew, vhosts.d that contains our 'location /.well-known/...' directive is included before the 'location /' target, and last one seems to bypass our LE location.
If our /.well-known location is defined as a prefix string (or as a regex), it takes priority over basic locations
Details on http://nginx.org/en/docs/http/ngx_http_core_module.html#location