### PR TITLE
switch to zenhack/simp_le

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -6,9 +6,9 @@ set -e
 apk --update add python py-requests py-setuptools git gcc py-pip musl-dev libffi-dev python-dev openssl-dev
 
 # Get Let's Encrypt simp_le client source
-branch="acme-0.8"
+branch="0.2.0"
 mkdir -p /src
-git -C /src clone --depth=1 -b $branch https://github.com/kuba/simp_le.git
+git -C /src clone --depth=1 --branch $branch https://github.com/zenhack/simp_le.git
 
 # Install simp_le in /usr/bin
 cd /src/simp_le


### PR DESCRIPTION
[kuba/simp_le](https://github.com/kuba/simp_le) have been abandoned by its author a year ago and hasn't been maintained since.

[zenhack's fork](https://github.com/zenhack/simp_le) appears to be the most actively maintained one.