### PR TITLE
Added support for choosing a certain key size via environment variable 'LETSENCRYPT_KEYSIZE'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Set the following environment variables to enable Let's Encrypt support for a co
 
 The `LETSENCRYPT_HOST` variable most likely needs to be the same as the `VIRTUAL_HOST` variable and must be publicly reachable domains. Specify multiple hosts with a comma delimiter.
 
+The following environment variables are optional and parameterize the way the Let's Encrypt client works.
+
+- `LETSENCRYPT_KEYSIZE`
+
+The `LETSENCRYPT_KEYSIZE` variable determines the size of the requested key (in bit, defaults to 4096).
+
 ##### multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates
 If you want to create multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates add the base domain as the first domain of the `LETSENCRYPT_HOST` environment variable.
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -5,6 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 seconds_to_wait=3600
 ACME_CA_URI="${ACME_CA_URI:-https://acme-v01.api.letsencrypt.org/directory}"
 ACME_TOS_HASH="${ACME_TOS_HASH:-6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221}"
+DEFAULT_KEY_SIZE=4096
 
 source /app/functions.sh
 
@@ -53,6 +54,12 @@ update_certs() {
         # Array variable indirection hack: http://stackoverflow.com/a/25880676/350221
         hosts_array=$host_varname[@]
         email_varname="LETSENCRYPT_${cid}_EMAIL"
+
+        keysize_varname="LETSENCRYPT_${cid}_KEYSIZE"
+        cert_keysize="${!keysize_varname}"
+        if [[ "$cert_keysize" == "<no value>" ]]; then
+            cert_keysize=$DEFAULT_KEY_SIZE
+        fi
 
         test_certificate_varname="LETSENCRYPT_${cid}_TEST"
         create_test_certificate=false
@@ -106,6 +113,7 @@ update_certs() {
             -f account_key.json -f key.pem -f chain.pem -f fullchain.pem -f cert.pem \
             --tos_sha256 $ACME_TOS_HASH \
             $params_d_str \
+            --cert_key_size=$cert_keysize \
             --email "${!email_varname}" \
             --server=$acme_ca_uri \
             --default_root /usr/share/nginx/html/

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -7,6 +7,7 @@ LETSENCRYPT_CONTAINERS=({{ range $hosts, $containers := groupBy $ "Env.LETSENCRY
 {{ range $container := $containers }}{{ $cid := printf "%.12s" $container.ID }}
 LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}'{{ $host }}' {{ end }})
 LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
+LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
 LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
 {{ end }}
 


### PR DESCRIPTION
I've added support to choose the key size of the keys/certificates letsencrypt-companion requests. NGINX does not have a problem with the default key size of 4096 bit, but other services like the cyrus imap server do not accept such large keys.

I would appreciate if you could merge my addition into your codebase, so I and (hopefully) other people can benefit from it in the future.

Thank you very much!