### PR TITLE
enable simp_le private key reutilisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ $ docker run -d \
 
 * `DEBUG` - Set it to `true` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pin point any configuration issues.
 
+* `REUSE_KEY` - Set it to `true` to make simp_le reuse previously generated private key instead of creating a new one on certificate renewal. Recommended if you intend to use HPKP.
+
 * The "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true" label - set this label on the nginx-proxy container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the proxy.
 
 * `ACME_TOS_HASH` - Let´s you pass an alternative TOS hash to simp_le, to support other CA´s ACME implentation.

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -69,6 +69,7 @@ update_certs() {
 
         params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
+        [[ $REUSE_KEY == true ]] && params_d_str+=" --reuse_key"
 
         hosts_array_expanded=("${!hosts_array}")
         # First domain will be our base domain


### PR DESCRIPTION
This enable the use of simp_le `--reuse_key` option via the new environment variable `REUSE_KEY`

Reusing the previous private key at certificate renewal instead of generating a new one is almost mandatory if you want to setup things like [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), as outlined in #217 

This commit has been tested on a real setup and is working as intended.