### PR TITLE
letsencrypt for other static sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,43 @@ $ docker run -d \
 
 * `ACME_TOS_HASH` - Let´s you pass an alternative TOS hash to simp_le, to support other CA´s ACME implentation.
 
+#### Static redirections
+
+You may want to define other servers than the ones in docker containers. You need to create a shell script file (that will be sourced) like this :
+
+```
+LETSENCRYPT_CONTAINERS+=( 'static_id1' )
+LETSENCRYPT_static_id1_HOST=( '<hostname>' )
+LETSENCRYPT_static_id1_EMAIL="<e-mail>"
+LETSENCRYPT_static_id1_KEYSIZE="<no-value>"
+#LETSENCRYPT_static_id1_TEST=""
+
+LETSENCRYPT_CONTAINERS+=( 'static_id2' )
+LETSENCRYPT_static_id2_HOST=( '<other hostname>' )
+LETSENCRYPT_static_id2_EMAIL="<e-mail>"
+LETSENCRYPT_static_id2_KEYSIZE="<no-value>"
+#LETSENCRYPT_static_id2_TEST=""
+```
+
+* `LETSENCRYPT_CONTAINERS` is the list of hosts (primarily the list of docker containers, but here we add our static hosts)
+* `LETSENCRYPT_<id>_HOST` : same as docker environment var `LETSENCRYPT_HOST`
+* `LETSENCRYPT_<id>_EMAIL` : same as docker environment var `LETSENCRYPT_EMAIL`
+* `LETSENCRYPT_<id>_TEST` : same as docker environment var `LETSENCRYPT_TEST` (optional)
+* `LETSENCRYPT_<id>_KEYSIZE` : same as docker environment var `LETSENCRYPT_KEYSIZE` (mandatory, but you can set to `<no value>` if you want the default size)
+
+Then you may start the letsencrypt_nginx_proxy_companion like this :
+
+```
+$ docker run -d \
+    --name nginx-letsencrypt \
+    -e "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" \
+    --volumes-from nginx \
+    -v /path/to/certs:/etc/nginx/certs:rw \
+    -v /path/to/letsencrypt_service_static_data:/etc/docker-letsencrypt-nginx-proxy-companion/letsencrypt_service_static_data:ro \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    jrcs/letsencrypt-nginx-proxy-companion
+```
+
 #### Examples:
 
 If you want other examples how to use this container, look at: 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -6,6 +6,7 @@ seconds_to_wait=3600
 ACME_CA_URI="${ACME_CA_URI:-https://acme-v01.api.letsencrypt.org/directory}"
 ACME_TOS_HASH="${ACME_TOS_HASH:-6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221}"
 DEFAULT_KEY_SIZE=4096
+STATIC_DATA_FILE=/etc/docker-letsencrypt-nginx-proxy-companion/letsencrypt_service_static_data
 
 source /app/functions.sh
 
@@ -45,7 +46,9 @@ update_certs() {
 
     # Load relevant container settings
     unset LETSENCRYPT_CONTAINERS
-    source "$DIR"/letsencrypt_service_data
+    cat "$DIR"/letsencrypt_service_data > /tmp/letsencrypt_service_data.tmp
+    [[ -f "${STATIC_DATA_FILE}" ]] && cat ${STATIC_DATA_FILE} >> /tmp/letsencrypt_service_data.tmp
+    source /tmp/letsencrypt_service_data.tmp
 
     reload_nginx='false'
     for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do


### PR DESCRIPTION
Hello,

docker-letsencrypt-nginx-proxy-companion is working well, with docker-gen, when you have web sites in a docker container in the same host as the nginx-proxy.

However, it could be extended to this use-case : I have another computer running some apache2 (it could be anything serving http on port 80). I want my nginx to reverse-proxy that web site too. And have nginx and docker-letsencrypt-nginx-proxy-companion doing the ssl. How could I do that ?

I analysed the container and I found it would be very easy to append some static data to /app/letsencrypt_service_data.

## Method 1

Write a file 

```
# Beginning of /app/letsencrypt_service_data.tmpl here
[...]
# then :
LETSENCRYPT_CONTAINERS+=( 'static_id1' )
LETSENCRYPT_static_id1_HOST=( 'my.example.com' )
LETSENCRYPT_static_id1_EMAIL="my.email@example.com"
LETSENCRYPT_static_id1_KEYSIZE="<no value>"
#LETSENCRYPT_static_id1_TEST=""
```

Then mount this file with docker -v /path/to/my/own/letsencrypt_service_data:/app/letsencrypt_service_data

With this method, there is nothing else to do. No Pull Request.

However, if I do that, I need to follow your /app/letsencrypt_service_data.tmpl and make mine any time you change yours.

I would prefer a mechanism to concatenate the _upstream_ file and my own file.

## Method 2

Have 2 files. The _upstream_ /app/letsencrypt_service_data.tmpl and my own file.

But it needs an change in /app/letsencrypt_service to do the concatenation. This is my Pull Request.

Thanks for helping proxify and ssl-ize web sites out of the docker world.

Regards,
Yves