### PR TITLE
Build a specific release of simp_le instead of master

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -6,13 +6,13 @@ set -e
 apk --update add python py-setuptools git gcc py-pip musl-dev libffi-dev python-dev openssl-dev
 
 # Get Let's Encrypt simp_le client source
-branch="master"
 mkdir -p /src
-git -C /src clone --depth=1 --branch $branch https://github.com/zenhack/simp_le.git
+git -C /src clone https://github.com/zenhack/simp_le.git
 
 # Install simp_le in /usr/bin
+release='0.3.0'
 cd /src/simp_le
-#pip install wheel requests
+git checkout "$release"
 for pkg in pip distribute setuptools wheel
 do
   pip install -U "${pkg?}"


### PR DESCRIPTION
I think this container should aim at predictable build, at least for the core `simp_le`.

The removal of `--depth=1` is required to be able to make a `git checkout` and only represents a delta of 124 Kb as of today.

The removal of `--branch` makes git clone `master` by default.

This PR does not revert the improvements made by @almereyda on #222 