### PR TITLE
Remove -only-exposed from docker-gen statement so that it will pick u…

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -16,7 +16,7 @@ trap 'term_handler' INT QUIT KILL TERM
 /app/letsencrypt_service &
 letsencrypt_service_pid=$!
 
-docker-gen -watch -only-exposed -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+docker-gen -watch -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
 docker_gen_pid=$!
 
 # wait "indefinitely"


### PR DESCRIPTION
Remove `-only-exposed` from the `docker-gen` statement in order to allow the `letsencrypt-companion` container to pickup containers that are in internal networks. 

Docker itself will not actually expose ports on containers that are in internal-only networks. This creates a problem when attempting to proxy web servers in containers that are on internal docker networks, as they will never be picked up by `letsencrypt-companion` since they technically do not have an "exposed" port.

Example: I'd like to proxy requests for a container running [Portainer](https://github.com/portainer/portainer). Since Portainer only interacts with the docker service itself, it can sit on an internal docker network for increased security. However, since `letsencrypt-companion` only picks up containers with exposed ports, and this Portainer container can't expose a port on an internal docker network, it will never get a cert created by `letsencrypt-companion`.

This might be better as some kind of option, maybe an environment variable that can be set, but since `letsencrypt-companion` is only looking for containers with the `LETSENCRYPT_HOST` and `LETSENCRYPT_EMAIL` environment variables anyway, it seems reasonable to just remove this argument from the `docker-gen` statement.