### PR TITLE
Disable auth for the acme-challenge location

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,4 +1,5 @@
 location /.well-known/acme-challenge/ {
+    auth_basic off;
     allow all;
     root /usr/share/nginx/html;
     try_files $uri =404;


### PR DESCRIPTION
As suggested in #112 

`/.well-known/acme-challenge` is indeed unreachable if `basic_auth` has been enabled on the nginx proxy container.

Tested and working as intended.