### PR TITLE
Add example for static names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ $ docker run -d \
 * Then start any containers to be proxied as described previously.
 
 Note: 
-If the 3 containers are using using static names. The label "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen" on nginx container can be removed. Additionally, evironment variables need to be set on the letsencrypt container. The docker environment variables to be set on the letsencrypt container are "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" and "NGINX_PROXY_CONTAINER=nginx".
+If the 3 containers are using static names, both labels `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` on nginx container and `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` on the docker-gen container can be removed. 
+
+The docker environment variables to be set on the letsencrypt container are:
+* `NGINX_DOCKER_GEN_CONTAINER` set to the name of the nginx container (here `nginx`)
+* `NGINX_PROXY_CONTAINER` set to the name of the docker-gen container (here `nginx-gen`)
+
 Example:
 ```bash
 $ docker run -d \

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ docker run -d \
 * Then start any containers to be proxied as described previously.
 
 Note: 
-If the 3 containers are using using static names, as shown in the examples. The label (`--label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen`) on `nginx` container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `NGINX_PROXY_CONTAINER=nginx`.
+If the 3 containers are using using static names, as shown in the examples. The label "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen" on nginx container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `NGINX_PROXY_CONTAINER=nginx`.
 Example:
 ```bash
 $ docker run -d \

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ docker run -d \
 * Then start any containers to be proxied as described previously.
 
 Note: 
-If the 3 containers are using using static names, as shown in the examples. The label "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen" on nginx container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `NGINX_PROXY_CONTAINER=nginx`.
+If the 3 containers are using using static names. The label "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen" on nginx container can be removed. Additionally, evironment variables need to be set on the letsencrypt container. The docker environment variables to be set on the letsencrypt container are "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" and "NGINX_PROXY_CONTAINER=nginx".
 Example:
 ```bash
 $ docker run -d \

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ docker run -d \
 * Then start any containers to be proxied as described previously.
 
 Note: 
-If the 3 containers are using using static names, as shown in the examples. The label (`--label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen`) on `nginx` container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `-e NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `-e NGINX_PROXY_CONTAINER=nginx`.
+If the 3 containers are using using static names, as shown in the examples. The label (`--label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen`) on `nginx` container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `NGINX_PROXY_CONTAINER=nginx`.
 Example:
 ```bash
 $ docker run -d \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,19 @@ $ docker run -d \
 
 * Then start any containers to be proxied as described previously.
 
-Note: If the docker-gen container name is static and you want to explicitly set it, use `-e NGINX_DOCKER_GEN_CONTAINER=nginx-gen`. The same thing is true with the nginx container (`-e NGINX_PROXY_CONTAINER=nginx`).
+Note: 
+If the 3 containers are using using static names, as shown in the examples. The label (`--label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen`) on `nginx` container can be removed and additional evironment variables set on the `letsencrypt-nginx-proxy-companion` container. The variables are `-e NGINX_DOCKER_GEN_CONTAINER=nginx-gen` and `-e NGINX_PROXY_CONTAINER=nginx`.
+Example:
+```bash
+$ docker run -d \
+    --name nginx-letsencrypt \
+    --volumes-from nginx \
+    -v /path/to/certs:/etc/nginx/certs:rw \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    -e NGINX_DOCKER_GEN_CONTAINER=nginx-gen \
+    -e NGINX_PROXY_CONTAINER=nginx \
+    jrcs/letsencrypt-nginx-proxy-companion
+```
 
 
 #### Let's Encrypt


### PR DESCRIPTION
Documentation was unclear regarding statically named contains and where the environment variables went. 