### PR TITLE
Fix for "host"-networked containers

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -16,7 +16,7 @@ trap 'term_handler' INT QUIT KILL TERM
 /app/letsencrypt_service &
 letsencrypt_service_pid=$!
 
-docker-gen -watch -only-exposed -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+docker-gen -watch -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
 docker_gen_pid=$!
 
 # wait "indefinitely"

--- a/app/start.sh
+++ b/app/start.sh
@@ -16,7 +16,10 @@ trap 'term_handler' INT QUIT KILL TERM
 /app/letsencrypt_service &
 letsencrypt_service_pid=$!
 
-docker-gen -watch -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+ARGS="-watch -notify '/app/update_certs' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data"
+[[ ${DISABLE_ONLY_EXPOSED^^} == YES || ${DISABLE_ONLY_EXPOSED^^} == TRUE ]] || ARGS="-only-exposed $ARGS"
+
+docker-gen $ARGS &
 docker_gen_pid=$!
 
 # wait "indefinitely"


### PR DESCRIPTION
We must turn off the "-only-exposed" flag on docker-gen if we have containers with "host" network.