### PR TITLE
Fix forced renewal of certificates

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -70,7 +70,7 @@ update_certs() {
         params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
         [[ $REUSE_KEY == true ]] && params_d_str+=" --reuse_key"
-        [[ "${1}" == "--force-renew" ]] && params_d_str+=" --valid_min 7776000" && shift
+        [[ "${1}" == "--force-renew" ]] && params_d_str+=" --valid_min 7776000"
 
         hosts_array_expanded=("${!hosts_array}")
         # First domain will be our base domain


### PR DESCRIPTION
Forced renewal with `/app/force_renew` currently renew only the first certificate it find on `letsencrypt_service_data` due to a `&& shift` that should not have been there in the first place (my mistake entirely).

@JrCs > could you please merge this as soon as convenient for you ? This feature is really needed for troubleshooting.