### PR TITLE
Update base image to Alpine 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,31 @@
-FROM alpine:3.3
+FROM alpine:3.6
 
-MAINTAINER Yves Blusseau <90z7oey02@sneakemail.com> (@blusseau)
+LABEL maintainer="Yves Blusseau <90z7oey02@sneakemail.com> (@blusseau)"
 
-ENV DEBUG=false              \
-	DOCKER_GEN_VERSION=0.7.3 \
-	DOCKER_HOST=unix:///var/run/docker.sock
+ENV DEBUG=false \
+    DOCKER_GEN_VERSION=0.7.3 \
+    DOCKER_HOST=unix:///var/run/docker.sock
 
-RUN apk --update add bash curl ca-certificates procps jq tar && \
-	curl -L -O https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \
-	tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \
-	rm -f docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \
-	apk del tar && \
-	rm -rf /var/cache/apk/*
+# Install packages required by the image
+RUN apk add --update \
+        bash \
+        ca-certificates \
+        curl \
+        jq \
+        openssl \
+    && rm /var/cache/apk/*
 
-WORKDIR /app
+# Install docker-gen
+RUN curl -L https://github.com/jwilder/docker-gen/releases/download/${DOCKER_GEN_VERSION}/docker-gen-linux-amd64-${DOCKER_GEN_VERSION}.tar.gz \
+    | tar -C /usr/local/bin -xz
 
-# Install simp_le program
+# Install simp_le
 COPY /install_simp_le.sh /app/install_simp_le.sh
 RUN chmod +rx /app/install_simp_le.sh && sync && /app/install_simp_le.sh && rm -f /app/install_simp_le.sh
 
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh" ]
-CMD ["/bin/bash", "/app/start.sh" ]
-
 COPY /app/ /app/
+
+WORKDIR /app
+
+ENTRYPOINT [ "/bin/bash", "/app/entrypoint.sh" ]
+CMD [ "/bin/bash", "/app/start.sh" ]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 
 set -u
 

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+# shellcheck disable=SC2155
+
 [[ -z "${VHOST_DIR:-}" ]] && \
  declare -r VHOST_DIR=/etc/nginx/vhost.d
 [[ -z "${START_HEADER:-}" ]] && \

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2120
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -9,15 +10,15 @@ DEFAULT_KEY_SIZE=4096
 source /app/functions.sh
 
 create_link() {
-    local readonly target=${1?missing target argument}
-    local readonly source=${2?missing source argument}
+    local -r target=${1?missing target argument}
+    local -r source=${2?missing source argument}
     [[ -f "$target" ]] && return 1
     ln -sf "$source" "$target"
 }
 
 create_links() {
-    local readonly base_domain=${1?missing base_domain argument}
-    local readonly domain=${2?missing base_domain argument}
+    local -r base_domain=${1?missing base_domain argument}
+    local -r domain=${2?missing base_domain argument}
 
     if [[ ! -f "/etc/nginx/certs/$base_domain"/fullchain.pem || \
           ! -f "/etc/nginx/certs/$base_domain"/key.pem ]]; then
@@ -44,6 +45,7 @@ update_certs() {
 
     # Load relevant container settings
     unset LETSENCRYPT_CONTAINERS
+    # shellcheck source=/dev/null
     source "$DIR"/letsencrypt_service_data
 
     reload_nginx='false'
@@ -51,7 +53,7 @@ update_certs() {
         # Derive host and email variable names
         host_varname="LETSENCRYPT_${cid}_HOST"
         # Array variable indirection hack: http://stackoverflow.com/a/25880676/350221
-        hosts_array=$host_varname[@]
+        hosts_array="${host_varname}[@]"
         email_varname="LETSENCRYPT_${cid}_EMAIL"
 
         keysize_varname="LETSENCRYPT_${cid}_KEYSIZE"
@@ -101,7 +103,7 @@ update_certs() {
 
         # Create directory for the first domain
         mkdir -p /etc/nginx/certs/$base_domain
-        cd /etc/nginx/certs/$base_domain
+        pushd /etc/nginx/certs/$base_domain
 
         for domain in "${!hosts_array}"; do
             # Add all the domains to certificate
@@ -121,7 +123,9 @@ update_certs() {
 
         simp_le_return=$?
 
-        for altnames in ${hosts_array_expanded[@]:1}; do
+        popd
+
+        for altnames in "${hosts_array_expanded[@]:1}"; do
             # Remove old CN domain that now are altnames
             rm -rf /etc/nginx/certs/$altnames
         done

--- a/app/start.sh
+++ b/app/start.sh
@@ -11,7 +11,7 @@ term_handler() {
     exit 143; # 128 + 15 -- SIGTERM
 }
 
-trap 'term_handler' INT QUIT KILL TERM
+trap 'term_handler' INT QUIT TERM
 
 /app/letsencrypt_service &
 letsencrypt_service_pid=$!

--- a/app/update_certs
+++ b/app/update_certs
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-pkill -f -SIGUSR1 /app/letsencrypt_service
+# Works with either procps pkill or busybox pkill
+pkill -f -SIGUSR1 /app/letsencrypt_service || pkill -USR1 -f /app/letsencrypt_service


### PR DESCRIPTION
This PR:

- provides a bit of shell linting (with [shellcheck](https://github.com/koalaman/shellcheck)).
- fix `update_certs` so that it works both with `procps`'s and `busybox`'s versions of `pkill`.
- updates the base image from `alpine:3.3` to `alpine:3.6` (required the former point to work).
- replace the deprecated `MAINTAINER` statement with `LABEL maintainer`.
- removes `procps` package as it does not provide `pkill` as of `alpine:3.4`.
- removes `tar` package as it is included in alpine (provided by `busybox`).
- adds `openssl` package as it is a runtime dependency of `simp_le` and was previously installed as a dependency of `curl` (that's no longer the case in `alpine:3.6`).
- prettify and streamline the Dockerfile.