### PR TITLE
Do not rm -rf with a trailing empty var

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -83,7 +83,7 @@ update_certs() {
             acme_ca_uri="https://acme-staging.api.letsencrypt.org/directory"
             if [[ ! -f /etc/nginx/certs/.${base_domain}.test ]]; then
                 # Remove old certificates
-                rm -rf /etc/nginx/certs/${base_domain}
+                [[ -n "${base_domain// }" ]] && rm -rf /etc/nginx/certs/${base_domain}
                 for domain in "${!hosts_array}"; do
                     rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
                 done
@@ -93,7 +93,7 @@ update_certs() {
             acme_ca_uri="$ACME_CA_URI"
             if [[ -f /etc/nginx/certs/.${base_domain}.test ]]; then
                 # Remove old test certificates
-                rm -rf /etc/nginx/certs/${base_domain}
+                [[ -n "${base_domain// }" ]] && rm -rf /etc/nginx/certs/${base_domain}
                 for domain in "${!hosts_array}"; do
                     rm -f /etc/nginx/certs/$domain.{crt,key,dhparam.pem}
                 done
@@ -127,7 +127,7 @@ update_certs() {
 
         for altnames in "${hosts_array_expanded[@]:1}"; do
             # Remove old CN domain that now are altnames
-            rm -rf /etc/nginx/certs/$altnames
+            [[ -n "${altnames// }" ]] && rm -rf /etc/nginx/certs/${altnames}
         done
 
         for domain in "${!hosts_array}"; do

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -2,15 +2,13 @@ LETSENCRYPT_CONTAINERS=({{ range $hosts, $containers := groupBy $ "Env.LETSENCRY
 
 {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
 
-{{ if trim $hosts }}
+{{ $hosts := trimSuffix "," $hosts }}
 
 {{ range $container := $containers }}{{ $cid := printf "%.12s" $container.ID }}
-LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}'{{ $host }}' {{ end }})
+LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}{{ $host := trim $host }}'{{ $host }}' {{ end }})
 LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
 LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
 LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
-{{ end }}
-
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
This fix safeguard against potential attempted forced deletions of `/etc/nginx/certs` when trying to do `rm -rf /etc/nginx/certs/$var` with a `var` that is empty or contains only spaces.

See #288 