### PR TITLE
Merge dev into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ If needed, you can force a running letsencrypt-nginx-proxy-companion container t
 $ docker exec nginx-letsencrypt /app/force_renew
 ```
 
+##### ACME account keys
+By default the container will save the first ACME account key created for each ACME API endpoint used, and will reuse it for all subsequent authorizations and issuances requests made to this endpoint. This behavior is enabled by default to avoid running into Let's Encrypt account [rate limits](https://letsencrypt.org/docs/rate-limits/).
+
+For instance, when using the default Let's Encrypt production endpoint, the container will save the first account key created for this endpoint as `/etc/nginx/certs/accounts/acme-v01.api.letsencrypt.org/directory/default.json` and will reuse it for future requests made to this endpoint.
+
+If required, you can use multiple accounts for the same ACME API endpoint by using the `LETSENCRYPT_ACCOUNT_ALIAS` environment variable on your proxyed container. This instruct the letsencrypt_nginx_proxy_companion container to look for an account key named after the provided alias instead of `default.json`. For example, `LETSENCRYPT_ACCOUNT_ALIAS=client1` will use the key named `client1.json` in the corresponding ACME API endpoint folder for this proxyed container (or will create it if it does not exists yet).
+
+Please see the **One Account or Many?** paragraph on [Let's Encrypt Integration Guide](https://letsencrypt.org/docs/integration-guide/) for additional informations.
+
+If you want to disable the account key reutilization entirely, you can set the environment variable `REUSE_ACCOUNT_KEYS` to `false` on the letsencrypt_nginx_proxy_companion container. This creates a new ACME registration with a corresponding account key for each new certificate issuance. Note that this won't create new account keys for certs already issued before `REUSE_ACCOUNT_KEYS` is set to `false`. This is not recommended unless you have specific reasons to do so.
+
 #### Optional container environment variables
 
 Optional letsencrypt-nginx-proxy-companion container environment variables for custom configuration.
@@ -190,6 +201,8 @@ $ docker run -d \
 ```
 
 * `DEBUG` - Set it to `true` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pin point any configuration issues.
+
+* `REUSE_ACCOUNT_KEYS` - Set it to `false` to disable the account keys reutilization (see [ACME account keys](#acme-account-keys)).
 
 * `REUSE_KEY` - Set it to `true` to make simp_le reuse previously generated private key instead of creating a new one on certificate renewal. Recommended if you intend to use HPKP.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](https://travis-ci.org/JrCs/docker-letsencrypt-nginx-proxy-companion.svg?branch=master)](https://travis-ci.org/JrCs/docker-letsencrypt-nginx-proxy-companion)
-[![](https://images.microbadger.com/badges/version/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
-[![](https://images.microbadger.com/badges/image/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
-[![](https://img.shields.io/docker/stars/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
-[![](https://img.shields.io/docker/pulls/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
+[![GitHub release](https://img.shields.io/github/release/jrcs/docker-letsencrypt-nginx-proxy-companion.svg)](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/releases)
+[![Image info](https://images.microbadger.com/badges/image/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
+[![Docker stars](https://img.shields.io/docker/stars/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
+[![Docker pulls](https://img.shields.io/docker/pulls/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
 
 letsencrypt-nginx-proxy-companion is a lightweight companion container for the [nginx-proxy](https://github.com/jwilder/nginx-proxy). It allows the creation/renewal of Let's Encrypt certificates automatically. See [Let's Encrypt section](#lets-encrypt) for configuration details.
 
@@ -106,8 +106,8 @@ $ docker run -d \
 
 * Then start any containers to be proxied as described previously.
 
-Note: 
-If the 3 containers are using static names, both labels `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` on nginx container and `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` on the docker-gen container can be removed. 
+Note:
+If the 3 containers are using static names, both labels `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` on nginx container and `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` on the docker-gen container can be removed.
 
 The docker environment variables to be set on the letsencrypt container are:
 * `NGINX_PROXY_CONTAINER` set to the name of the nginx container (here `nginx`)
@@ -145,10 +145,10 @@ The `LETSENCRYPT_KEYSIZE` variable determines the size of the requested key (in 
 
 **Note:** the `VIRTUAL_HOST` (or `LETSENCRYPT_HOST`) must be a reachable domain for LetEncrypt to be able to validate the challenge and provide the certificate.
 
-##### multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates
+##### Multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates
 If you want to create multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates add the base domain as the first domain of the `LETSENCRYPT_HOST` environment variable.
 
-##### test certificates
+##### Test certificates
 If you want to create test certificates that don't have the 5 certs/week/domain limits define the `LETSENCRYPT_TEST` environment variable with a value of `true` (in the containers where you request certificates with LETSENCRYPT_HOST). If you want to do this globally for all containers, set ACME_CA_URI as described below.
 
 ##### Automatic certificate renewal
@@ -164,9 +164,9 @@ $ docker run -d \
     tutum/apache-php
 ```
 
-#### Force certificates renewal
+##### Force certificates renewal
 
-If needed, you can force a running letsencrypt-nginx-proxy-companion container to renew all certificates that are currently in use. Replace `nginx-letsencrypt` with the name of your `letsencrypt-nginx-proxy-companion` container in the following command:
+If needed, you can force a running letsencrypt-nginx-proxy-companion container to renew all certificates that are currently in use. Replace `nginx-letsencrypt` with the name of your letsencrypt-nginx-proxy-companion container in the following command:
 
 ```bash
 $ docker exec nginx-letsencrypt /app/force_renew
@@ -187,7 +187,7 @@ If you want to disable the account key reutilization entirely, you can set the e
 
 Optional letsencrypt-nginx-proxy-companion container environment variables for custom configuration.
 
-* `ACME_CA_URI` - Directory URI for the CA ACME API endpoint (default: ``https://acme-v01.api.letsencrypt.org/directory``). If you set it's value to `https://acme-staging.api.letsencrypt.org/directory` letsencrypt will use test servers that don't have the 5 certs/week/domain limits. You can also create test certificates per container (see [let's encrypt test certificates](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/blob/doc/README.md#test-certificates))
+* `ACME_CA_URI` - Directory URI for the CA ACME API endpoint (default: ``https://acme-v01.api.letsencrypt.org/directory``). If you set it's value to `https://acme-staging.api.letsencrypt.org/directory` letsencrypt will use test servers that don't have the 5 certs/week/domain limits. You can also create test certificates per container (see [let's encrypt test certificates](#test-certificates))
 
 For example
 
@@ -206,9 +206,9 @@ $ docker run -d \
 
 * `REUSE_KEY` - Set it to `true` to make simp_le reuse previously generated private key instead of creating a new one on certificate renewal. Recommended if you intend to use HPKP.
 
-* The "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy" label - set this label on the nginx-proxy container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the proxy.
+* The `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` label - set this label on the nginx-proxy container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the proxy.
 
-* The "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen" label - set this label on the docker-gen container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the docker-gen when it's split from nginx (separate containers).
+* The `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` label - set this label on the docker-gen container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the docker-gen when it's split from nginx (separate containers).
 
 * `ACME_TOS_HASH` - Let´s you pass an alternative TOS hash to simp_le, to support other CA´s ACME implentation.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $ docker run -d \
 
 * `REUSE_ACCOUNT_KEYS` - Set it to `false` to disable the account keys reutilization (see [ACME account keys](#acme-account-keys)).
 
-* `REUSE_KEY` - Set it to `true` to make simp_le reuse previously generated private key instead of creating a new one on certificate renewal. Recommended if you intend to use HPKP.
+* `REUSE_PRIVATE_KEYS` - Set it to `true` to make simp_le reuse previously generated private key for each certificate instead of creating a new one on certificate renewal. Recommended if you intend to use HPKP.
 
 * The `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` label - set this label on the nginx-proxy container to tell the docker-letsencrypt-nginx-proxy-companion container to use it as the proxy.
 

--- a/README.md
+++ b/README.md
@@ -128,31 +128,9 @@ $ docker run -d \
 
 #### Let's Encrypt
 
-To use the Let's Encrypt service to automatically create a valid certificate for virtual host(s).
+To use the Let's Encrypt service to automatically create a valid certificate for virtual host(s), declare the `LETSENCRYPT_HOST` environment variable in each to-be-proxied application containers.
 
-Set the following environment variables to enable Let's Encrypt support for a container being proxied. This environment variables need to be declared in each to-be-proxied application containers.
-
-- `LETSENCRYPT_HOST`
-- `LETSENCRYPT_EMAIL`
-
-The `LETSENCRYPT_HOST` variable most likely needs to be the same as the `VIRTUAL_HOST` variable and must be publicly reachable domains. Specify multiple hosts with a comma delimiter.
-
-The following environment variables are optional and parameterize the way the Let's Encrypt client works.
-
-- `LETSENCRYPT_KEYSIZE`
-
-The `LETSENCRYPT_KEYSIZE` variable determines the size of the requested key (in bit, defaults to 4096).
-
-**Note:** the `VIRTUAL_HOST` (or `LETSENCRYPT_HOST`) must be a reachable domain for LetEncrypt to be able to validate the challenge and provide the certificate.
-
-##### Multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates
-If you want to create multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates add the base domain as the first domain of the `LETSENCRYPT_HOST` environment variable.
-
-##### Test certificates
-If you want to create test certificates that don't have the 5 certs/week/domain limits define the `LETSENCRYPT_TEST` environment variable with a value of `true` (in the containers where you request certificates with LETSENCRYPT_HOST). If you want to do this globally for all containers, set ACME_CA_URI as described below.
-
-##### Automatic certificate renewal
-Every hour (3600 seconds) the certificates are checked and every certificate that will expire in the next [30 days](https://github.com/kuba/simp_le/blob/ecf4290c4f7863bb5427b50cdd78bc3a5df79176/simp_le.py#L72) (90 days / 3) are renewed.
+The `LETSENCRYPT_HOST` variable most likely needs to be set to the same value as the `VIRTUAL_HOST` variable and must be publicly reachable domains. Specify multiple hosts with a comma delimiter.
 
 ##### Example:
 ```bash
@@ -163,6 +141,31 @@ $ docker run -d \
     -e "LETSENCRYPT_EMAIL=foo@bar.com" \
     tutum/apache-php
 ```
+
+**Note:** the `VIRTUAL_HOST` (and `LETSENCRYPT_HOST`) must be (a) reachable domain(s) for LetEncrypt to be able to validate the challenge and provide the certificate.
+
+**Note on CAA**: Please ensure that your DNS provider answers correctly to CAA record requests. [If your DNS provider answer with an error, Let's Encrypt won't issue a certificate for your domain](https://letsencrypt.org/docs/caa/). Let's Encrypt do not require that you set a CAA record on your domain, just that your DNS provider answers correctly.
+
+**Note on IPv6**: If the domain or subdomain you want to issue certificate for has an AAAA record set, Let's Encrypt will favor challenge validation over IPv6. [There is an IPv6 to IPv4 fallback in place but Let's Encrypt cannot guarantee it'll work in every possible case](https://github.com/letsencrypt/boulder/issues/2770#issuecomment-340489871), so bottom line is **if you are not sure of both your host and your host's Docker reachability over IPv6, do not advertise an AAAA record** or LE challenge validation might fail.
+
+The following environment variables are optional and parameterize the way the Let's Encrypt client works.
+
+##### Contact address
+
+The `LETSENCRYPT_EMAIL` variable must be a valid email and will be used by Let's Encrypt to warn you of impeding certificate expiration (should the automated renewal fail) or for account recovery. It is strongly advised to provide a valid contact address using this variable.
+
+##### Private key size
+
+The `LETSENCRYPT_KEYSIZE` variable determines the size of the requested key (in bit, defaults to 4096).
+
+##### Multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates
+If you want to create multi-domain ([SAN](https://www.digicert.com/subject-alternative-name.htm)) certificates add the base domain as the first domain of the `LETSENCRYPT_HOST` environment variable (see [the example](#example) above).
+
+##### Test certificates
+If you want to create test certificates that don't have the 5 certs/week/domain limits define the `LETSENCRYPT_TEST` environment variable with a value of `true` (in the containers where you request certificates with `LETSENCRYPT_HOST`). If you want to do this globally for all containers, set `ACME_CA_URI` as described below.
+
+##### Automatic certificate renewal
+Every hour (3600 seconds) the certificates are checked and every certificate that will expire in the next [30 days](https://github.com/kuba/simp_le/blob/ecf4290c4f7863bb5427b50cdd78bc3a5df79176/simp_le.py#L72) (90 days / 3) are renewed.
 
 ##### Force certificates renewal
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -3,11 +3,12 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+source /app/functions.sh
+
 seconds_to_wait=3600
 ACME_CA_URI="${ACME_CA_URI:-https://acme-v01.api.letsencrypt.org/directory}"
 DEFAULT_KEY_SIZE=4096
-
-source /app/functions.sh
+REUSE_ACCOUNT_KEYS="$(lc ${REUSE_ACCOUNT_KEYS:-true})"
 
 create_link() {
     local -r target=${1?missing target argument}
@@ -68,6 +69,12 @@ update_certs() {
             create_test_certificate=true
         fi
 
+        account_varname="LETSENCRYPT_${cid}_ACCOUNT_ALIAS"
+        account_alias="${!account_varname}"
+        if [[ "$account_alias" == "<no value>" ]]; then
+            account_alias=default
+        fi
+
         params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
         [[ -n $ACME_TOS_HASH ]] && params_d_str+=" --tos_sha256 $ACME_TOS_HASH"
@@ -112,6 +119,22 @@ update_certs() {
             add_location_configuration "$domain" || reload_nginx
         done
 
+        # The ACME account key full path is derived from the endpoint URI
+        # + the account alias (set to 'default' if no alias is provided)
+        account_key_dir="/etc/nginx/certs/accounts/${acme_ca_uri#*://}"
+        account_key_full_path="${account_key_dir}/${account_alias}.json"
+        if [[ $REUSE_ACCOUNT_KEYS == true ]]; then
+            if [[ -f "$account_key_full_path" ]]; then
+                # If there is no symlink to the account key, create it
+                if [[ ! -L ./account_key.json ]]; then
+                    ln -sf "$account_key_full_path" ./account_key.json
+                # If the symlink target the wrong account key, replace it
+                elif [[ "$(readlink -f ./account_key.json)" != "$account_key_full_path" ]]; then
+                    ln -sf "$account_key_full_path" ./account_key.json
+                fi
+            fi
+        fi
+
         echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
         /usr/bin/simp_le \
             -f account_key.json -f key.pem -f chain.pem -f fullchain.pem -f cert.pem \
@@ -122,6 +145,16 @@ update_certs() {
             --default_root /usr/share/nginx/html/
 
         simp_le_return=$?
+
+        if [[ $REUSE_ACCOUNT_KEYS == true ]]; then
+            # If the account key to be reused does not exist yet, copy it
+            # from the CWD and replace the file in CWD with a symlink
+            if [[ ! -f "$account_key_full_path" && -f ./account_key.json ]]; then
+                mkdir -p "$account_key_dir"
+                cp ./account_key.json "$account_key_full_path"
+                ln -sf "$account_key_full_path" ./account_key.json
+            fi
+        fi
 
         popd
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -9,6 +9,7 @@ seconds_to_wait=3600
 ACME_CA_URI="${ACME_CA_URI:-https://acme-v01.api.letsencrypt.org/directory}"
 DEFAULT_KEY_SIZE=4096
 REUSE_ACCOUNT_KEYS="$(lc ${REUSE_ACCOUNT_KEYS:-true})"
+REUSE_PRIVATE_KEYS="$(lc ${REUSE_PRIVATE_KEYS:-false})"
 
 create_link() {
     local -r target=${1?missing target argument}
@@ -78,7 +79,7 @@ update_certs() {
         params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
         [[ -n $ACME_TOS_HASH ]] && params_d_str+=" --tos_sha256 $ACME_TOS_HASH"
-        [[ $REUSE_KEY == true ]] && params_d_str+=" --reuse_key"
+        [[ $REUSE_PRIVATE_KEYS == true ]] && params_d_str+=" --reuse_key"
         [[ "${1}" == "--force-renew" ]] && params_d_str+=" --valid_min 7776000"
 
         hosts_array_expanded=("${!hosts_array}")

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -56,7 +56,14 @@ update_certs() {
         host_varname="LETSENCRYPT_${cid}_HOST"
         # Array variable indirection hack: http://stackoverflow.com/a/25880676/350221
         hosts_array="${host_varname}[@]"
+
+        params_d_str=""
+
         email_varname="LETSENCRYPT_${cid}_EMAIL"
+        email_address="${!email_varname}"
+        if [[ "$email_address" != "<no value>" ]]; then
+            params_d_str+=" --email $email_address"
+        fi
 
         keysize_varname="LETSENCRYPT_${cid}_KEYSIZE"
         cert_keysize="${!keysize_varname}"
@@ -78,7 +85,6 @@ update_certs() {
             account_alias=default
         fi
 
-        params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
         [[ -n $ACME_TOS_HASH ]] && params_d_str+=" --tos_sha256 $ACME_TOS_HASH"
         [[ $REUSE_PRIVATE_KEYS == true ]] && params_d_str+=" --reuse_key"
@@ -143,7 +149,6 @@ update_certs() {
             -f account_key.json -f key.pem -f chain.pem -f fullchain.pem -f cert.pem \
             $params_d_str \
             --cert_key_size=$cert_keysize \
-            --email "${!email_varname}" \
             --server=$acme_ca_uri \
             --default_root /usr/share/nginx/html/
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -68,6 +68,8 @@ update_certs() {
         create_test_certificate=false
         if [[ $(lc "${!test_certificate_varname:-}") == true ]]; then
             create_test_certificate=true
+        elif [[ $ACME_CA_URI == "https://acme-staging.api.letsencrypt.org/directory" ]]; then
+            create_test_certificate=true
         fi
 
         account_varname="LETSENCRYPT_${cid}_ACCOUNT_ALIAS"

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -9,6 +9,7 @@ LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}{{ $host := t
 LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
 LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
 LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
+LETSENCRYPT_{{ $cid }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
In addition to the improved handling of ACME account keys decribed in #291 , this PR:

- change the name of env var `REUSE_KEY` to `REUSE_PRIVATE_KEYS` to avoid confusion with the new `REUSE_ACCOUNT_KEYS`environment variable.
- make the the container behave the same when you set `LETSENCRYPT_TEST` to `true` on a proxyed container and when you set the `ACME_CA_URI `environment variable to the Let's Encrypt staging api endpoint. Previously certs generated when explicitly using the LE stating api endpoint where not really considered test certificates by the container.
- avoids `--email` being passed to `simp_le` with no address when `LETSENCRYPT_EMAIL`is not set, making the contact email truly optional (and preventing issues like #263)
- update the doc to take all that into account and add two notes about CAA DNS records and IPv6.