### PR TITLE
Modify to work with AWS ECS

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
-# shellcheck disable=SC2155
+# shellcheck disable=SC2155,SC2002
 
-set -u
+set -e
 
-export CONTAINER_ID=$(cat /proc/self/cgroup | sed -nE 's/^.+docker[\/-]([a-f0-9]{64}).*/\1/p' | head -n 1)
+if [[ -n "${DOCKER_PROVIDER}" ]] && [[ "${DOCKER_PROVIDER,,}" == "aws" ]]; then
+  export CONTAINER_ID=$(cat "${ECS_CONTAINER_METADATA_FILE}" | grep ContainerID | sed 's/.*: "\(.*\)",/\1/g')
+else
+  export CONTAINER_ID=$(cat /proc/self/cgroup | sed -nE 's/^.+docker[\/-]([a-f0-9]{64}).*/\1/p' | head -n 1)
+fi
 
 if [[ -z "$CONTAINER_ID" ]]; then
     echo "Error: can't get my container ID !" >&2


### PR DESCRIPTION
In ECS the `/proc/self/cgroup` contains the prefix `/ecs/` not `/docker/` (likely the issue with other hosts such as kubernetes)

The "aws" fix here is to use the `ECS_CONTAINER_METADATA_FILE` env var [provided by ecs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)

Im open to modifying it as well to instead take an override for the sed:

```
CGROUP_PREFIX="${CGROUP_PREFIX:-docker}"
export CONTAINER_ID=$(cat /proc/self/cgroup | sed -nE "s/^.+$CGROUP_PREFIX[\/-]([a-f0-9]{64}).*/\1/p" | head -n 1)
```