### PR TITLE
Fix getting container ID for AWS Elastic Beanstalk Multi-container docker env

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -3,7 +3,7 @@
 
 set -u
 
-export CONTAINER_ID=$(cat /proc/self/cgroup | sed -nE 's/^.+docker[\/-]([a-f0-9]{64}).*/\1/p' | head -n 1)
+export CONTAINER_ID=$(cat /proc/self/cgroup | grep "cpu:/" | sed -r 's/.+\/([^\/]+)$/\1/')
 
 if [[ -z "$CONTAINER_ID" ]]; then
     echo "Error: can't get my container ID !" >&2


### PR DESCRIPTION
Hi, 

half a year ago I was able get this container up and running on AWS Elastic Beanstalk ([post](https://vfeskov.com/2017/04/15/free-https-on-multi-container-elastic-beanstalk-without-load-balancer/)), platform was:

> 64bit Amazon Linux 2017.03 v2.6.0 running 
> Multi-container Docker 1.12.6 (Generic)

Now I'm moving my instance to another region, and there a newer platform is used:

> 64bit Amazon Linux 2017.09 v2.8.3 running
> Multi-container Docker 17.06.2-ce (Generic)

On the new platform getting container ID doesn't work anymore in `entrypoint.sh`, I see the following when I inspect `cgroup`:

```
bash-4.4# cat /proc/self/cgroup | grep "cpu:/"
2:cpu:/ecs/1512a432-1234-5678-9012-c1113b789f24/f6fa8d24453bf032b6aae08a93c12a6874faf7ae765e9e5506eb0bbc3c2deb74
```

I modified `sed` command to extract container id correctly, what do you think about it? Can you please suggest a better command to keep it backwards compatible?