### PR TITLE
Add ^~ to location directive

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,4 +1,4 @@
-location /.well-known/acme-challenge/ {
+location ^~ /.well-known/acme-challenge/ {
     auth_basic off;
     allow all;
     root /usr/share/nginx/html;


### PR DESCRIPTION
This is a small change to make the matching a little bit faster, while also allowing more general blocking.

First some reference to the docs.
> If the longest matching prefix location has the “^~” modifier then regular expressions are not checked. 

[Nginx http_core_module](https://nginx.org/en/docs/http/ngx_http_core_module.html#location)
Further, from the docs, the evaluation order is the following;
1. Exact matches (using the = modifier)
2. Implicit prefix matching(no modifier or ^~)
3. Regex(~ and ~*)
 
As such, without a modifier(such as ^~), the location directive matches with the prefix of the challenge address, but can be overridden by a subsequent regex directive. An example is a general regex block for dot-files and dot-folders, such as this example taken from nextcloud;
> location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console) {

By adding the ^~ modifier, we tell nginx to stop at step 2 and use that location block, and not look any further.

From what I've seen, this was removed earlier with the reason 
>Don't need to use a regexp because the vhost.d/default configuration must be include specificaly in each server configurations by the nginx.tmpl template file.

This is fine for hosts which are proxied straight through the nginx proxy, however, for hosts with custom configuration(such as a fpm container mounted on the nginx proxy), vhost.d/default is not included, and the directive is instead inserted at the top of the configuration file for that vhost definition which probably contain other location directives. I would also like to emphasize that ^~ is not a regex-modifer, it tells nginx to _not_ look at regex locations.

I hope it's okay to just send a pull request like this, and looking forward to any input.