### PR TITLE
Fix unwanted custom cert removal #351

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -92,7 +92,7 @@ function cleanup_links {
       for disabled_domain in "${DISABLED_DOMAINS[@]}"; do
           for extension in .crt .key .dhparam.pem .chain.pem; do
               file="${disabled_domain}${extension}"
-              if [[ -n "${file// }" ]] && [[ -f "/etc/nginx/certs/${file}" ]]; then
+              if [[ -n "${file// }" ]] && [[ -L "/etc/nginx/certs/${file}" ]]; then
                   rm -f "/etc/nginx/certs/${file}"
               fi
           done


### PR DESCRIPTION
Fix for issue #351, prevents accidental deletion of custom certificates.

A version containing this fix has been pushed as `latest` and `v1.8` on DockerHub.