### PR TITLE
Test README typos

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -13,20 +13,20 @@ test/setup/setup-local.sh --setup
 Then build the docker image and run the tests:
 
 ```bash
-docker build -t jrcs/letsencrypt_nginx_proxy_companion .
-test/run.sh jrcs/letsencrypt_nginx_proxy_companion
+docker build -t jrcs/letsencrypt-nginx-proxy-companion .
+test/run.sh jrcs/letsencrypt-nginx-proxy-companion
 ```
 
 You can limit the test run to specific test(s) with the `-t` flag:
 
 ```bash
-test/run.sh -t docker_api jrcs/letsencrypt_nginx_proxy_companion
+test/run.sh -t docker_api jrcs/letsencrypt-nginx-proxy-companion
 ```
 
 When running the test suite, the standard output of each individual test is captured and compared to its expected-std-out.txt file. When developing or modifying a test, you can use the `--dry-run` flag to disable the standard output capture by the test suite.
 
 ```bash
-test/run.sh --dry-run jrcs/letsencrypt_nginx_proxy_companion
+test/run.sh --dry-run jrcs/letsencrypt-nginx-proxy-companion
 ```
 
 To remove the test setup:


### PR DESCRIPTION
Erroneous underscores in the container name replaced with dashes.