### PR TITLE
Fix test suite breakage due to boulder update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
     - le1.wtf
     - le2.wtf
     - le3.wtf
-    - boulder
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > docker-compose.temp
+  - curl -L https://github.com/docker/compose/releases/download/1.21.1/docker-compose-`uname -s`-`uname -m` > docker-compose.temp
   - chmod +x docker-compose.temp
   - sudo mv docker-compose.temp /usr/local/bin/docker-compose
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -207,8 +207,7 @@ if [[ -z $TRAVIS_CI ]] && [[ -f "$dir/local_test_env.sh" ]]; then
 	source "$dir/local_test_env.sh"
 fi
 
-BOULDER_IP="$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' boulder)" \
-	&& export BOULDER_IP
+BOULDER_IP="10.77.77.1" && export BOULDER_IP
 
 # shellcheck source=./tests/test-functions.sh
 source "$dir/tests/test-functions.sh"

--- a/test/setup/setup-boulder.sh
+++ b/test/setup/setup-boulder.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SERVER=http://localhost:4000/directory
+SERVER='http://10.77.77.1:4000/directory'
 
 setup_boulder() {
   # Per the boulder README:
@@ -16,9 +16,9 @@ setup_boulder() {
   sed --in-place 's/ 5002/ 80/g' test/config/va.json
   sed --in-place 's/ 5001/ 443/g' test/config/va.json
   sed --in-place 's/le.wtf,le1.wtf/le1.wtf,le2.wtf,le3.wtf/g' test/rate-limit-policies.yml
-  docker-compose pull
-  docker-compose build
+  docker-compose build --pull
   docker-compose run -d \
+    --use-aliases \
     --name boulder \
     -e FAKE_DNS=$nginx_proxy_ip \
     --service-ports \

--- a/test/setup/setup-local.sh
+++ b/test/setup/setup-local.sh
@@ -23,7 +23,6 @@ function get_environment {
 
   # Build the array containing domains to add to /etc/hosts
   IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
-  domains+=("boulder")
 
   if [[ -z $SETUP ]]; then
     while true; do

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -16,7 +16,6 @@ function run_le_container {
     --name "$name" \
     --volumes-from $NGINX_CONTAINER_NAME \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-    --add-host boulder:${BOULDER_IP} \
     --env "DEBUG=true" \
     --env "ACME_CA_URI=http://${BOULDER_IP}:4000/directory" \
     --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \


### PR DESCRIPTION
[Recent changes](https://github.com/letsencrypt/boulder/pull/3679) to boulder's `docker-compose.yml` file broke the test suite.

This PR fix Boulder setup and integration tests with the current version of Boulder.