### PR TITLE
Enable tests on macOS

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 ### letsencrypt-nginx-proxy-companion test suite
 
-The test suite can be run locally on a Linux host.
+The test suite can be run locally on a Linux or macOS host.
 
 To prepare the test setup:
 
@@ -23,10 +23,10 @@ You can limit the test run to specific test(s) with the `-t` flag:
 test/run.sh -t docker_api jrcs/letsencrypt-nginx-proxy-companion
 ```
 
-When running the test suite, the standard output of each individual test is captured and compared to its expected-std-out.txt file. When developing or modifying a test, you can use the `--dry-run` flag to disable the standard output capture by the test suite.
+When running the test suite, the standard output of each individual test is captured and compared to its expected-std-out.txt file. When developing or modifying a test, you can use the `-d` flag to disable the standard output capture by the test suite.
 
 ```bash
-test/run.sh --dry-run jrcs/letsencrypt-nginx-proxy-companion
+test/run.sh -d jrcs/letsencrypt-nginx-proxy-companion
 ```
 
 To remove the test setup:

--- a/test/run.sh
+++ b/test/run.sh
@@ -227,7 +227,17 @@ EOUSAGE
 }
 
 # arg handling
-opts="$(getopt -o 'ht:c:?' --long 'dry-run,help,test:,config:,keep-namespace' -- "$@" || { usage >&2 && false; })"
+## Next nine lines were added or modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+case "$(uname)" in
+	Linux)
+	opts="$(getopt -o 'hdkt:c:?' --long 'dry-run,help,test:,config:,keep-namespace' -- "$@" || { usage >&2 && false; })"
+	;;
+
+	Darwin)
+	opts="$(getopt hdkt:c:? "$@" || { usage >&2 && false; })"
+	;;
+esac
+## End of additional or modified code
 eval set -- "$opts"
 
 declare -A argTests=()
@@ -238,11 +248,13 @@ while true; do
 	flag=$1
 	shift
 	case "$flag" in
-		--dry-run) dryRun=1 ;;
+		## Next line was modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		--dry-run|-d) dryRun=1 ;;
 		--help|-h|'-?') usage && exit 0 ;;
 		--test|-t) argTests["$1"]=1 && shift ;;
 		--config|-c) configs+=("$(readlink -f "$1")") && shift ;;
-		--keep-namespace) keepNamespace=1 ;;
+		## Next line was modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		--keep-namespace|-k) keepNamespace=1 ;;
 		--) break ;;
 		*)
 			{

--- a/test/setup/setup-boulder.sh
+++ b/test/setup/setup-boulder.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SERVER='http://10.77.77.1:4000/directory'
+acme_endpoint='http://boulder:4000/directory'
 
 setup_boulder() {
   # Per the boulder README:
@@ -13,14 +13,20 @@ setup_boulder() {
     && git clone --depth=1 https://github.com/letsencrypt/boulder \
       $GOPATH/src/github.com/letsencrypt/boulder
   pushd $GOPATH/src/github.com/letsencrypt/boulder
-  sed --in-place 's/ 5002/ 80/g' test/config/va.json
-  sed --in-place 's/ 5001/ 443/g' test/config/va.json
-  sed --in-place 's/le.wtf,le1.wtf/le1.wtf,le2.wtf,le3.wtf/g' test/rate-limit-policies.yml
+  if [[ "$(uname)" == 'Darwin' ]]; then
+    sed -i '' 's/ 5002/ 80/g' test/config/va.json
+    sed -i '' 's/ 5001/ 443/g' test/config/va.json
+    sed -i '' 's/le.wtf,le1.wtf/le1.wtf,le2.wtf,le3.wtf/g' test/rate-limit-policies.yml
+  else
+    sed --in-place 's/ 5002/ 80/g' test/config/va.json
+    sed --in-place 's/ 5001/ 443/g' test/config/va.json
+    sed --in-place 's/le.wtf,le1.wtf/le1.wtf,le2.wtf,le3.wtf/g' test/rate-limit-policies.yml
+  fi
   docker-compose build --pull
   docker-compose run -d \
     --use-aliases \
     --name boulder \
-    -e FAKE_DNS=$nginx_proxy_ip \
+    -e FAKE_DNS=${nginx_proxy_ip:?} \
     --service-ports \
     boulder
   popd
@@ -28,13 +34,13 @@ setup_boulder() {
 
 wait_for_boulder() {
   i=0
-  until curl ${SERVER?} >/dev/null 2>&1; do
+  until docker exec boulder bash -c "curl ${acme_endpoint:?} >/dev/null 2>&1"; do
     if [ $i -gt 300 ]; then
       echo "Boulder has not started for 5 minutes, timing out."
       exit 1
     fi
     i=$((i + 5))
-    echo "$SERVER : connection refused, Boulder isn't ready yet. Waiting."
+    echo "$acme_endpoint : connection refused, Boulder isn't ready yet. Waiting."
     sleep 5
   done
 }

--- a/test/setup/setup-local.sh
+++ b/test/setup/setup-local.sh
@@ -11,15 +11,15 @@ function get_environment {
     source "${TRAVIS_BUILD_DIR}/test/local_test_env.sh"
 
   # Get the environment variables from the .travis.yml file with sed
-  declare -A travis_yml
-  travis_yml[nginx]="$(sed -n 's/.*- NGINX_CONTAINER_NAME=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
-  travis_yml[docker_gen]="$(sed -n 's/.*- DOCKER_GEN_CONTAINER_NAME=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
-  travis_yml[test_domains]="$(sed -n 's/.*- TEST_DOMAINS=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
+  declare -a travis_yml
+  travis_yml[0]="$(sed -n 's/.*- NGINX_CONTAINER_NAME=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
+  travis_yml[1]="$(sed -n 's/.*- DOCKER_GEN_CONTAINER_NAME=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
+  travis_yml[2]="$(sed -n 's/.*- TEST_DOMAINS=//p' "$LOCAL_BUILD_DIR/.travis.yml")"
 
   # If environment variable where sourced or manually set use them, else use those from .travis.yml
-  export NGINX_CONTAINER_NAME="${NGINX_CONTAINER_NAME:-${travis_yml[nginx]}}"
-  export DOCKER_GEN_CONTAINER_NAME="${DOCKER_GEN_CONTAINER_NAME:-${travis_yml[docker_gen]}}"
-  export TEST_DOMAINS="${TEST_DOMAINS:-${travis_yml[test_domains]}}"
+  export NGINX_CONTAINER_NAME="${NGINX_CONTAINER_NAME:-${travis_yml[0]}}"
+  export DOCKER_GEN_CONTAINER_NAME="${DOCKER_GEN_CONTAINER_NAME:-${travis_yml[1]}}"
+  export TEST_DOMAINS="${TEST_DOMAINS:-${travis_yml[2]}}"
 
   # Build the array containing domains to add to /etc/hosts
   IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
@@ -53,6 +53,7 @@ function get_environment {
 case $1 in
   --setup)
     get_environment
+
     # Prepare the env file that run.sh will source
     cat > "${TRAVIS_BUILD_DIR}/test/local_test_env.sh" <<EOF
 export TRAVIS_BUILD_DIR="$LOCAL_BUILD_DIR"
@@ -61,6 +62,7 @@ export DOCKER_GEN_CONTAINER_NAME="$DOCKER_GEN_CONTAINER_NAME"
 export TEST_DOMAINS="$TEST_DOMAINS"
 export SETUP="$SETUP"
 EOF
+
     # Add the required custom entries to /etc/hosts
     echo "Adding custom entries to /etc/hosts (requires sudo)."
     for domain in "${domains[@]}"; do
@@ -68,23 +70,29 @@ EOF
         || echo "127.0.0.1 $domain # le-companion test suite" \
         | sudo tee -a /etc/hosts
     done
+
     # Pull nginx:alpine
     docker pull nginx:alpine
+
     # Prepare the test setup using the setup scripts
     "${TRAVIS_BUILD_DIR}/test/setup/setup-nginx-proxy.sh"
     "${TRAVIS_BUILD_DIR}/test/setup/setup-boulder.sh"
     ;;
+
   --teardown)
     get_environment
+
     # Stop and remove boulder
     docker-compose --project-name 'boulder' \
       --file "${TRAVIS_BUILD_DIR}/go/src/github.com/letsencrypt/boulder/docker-compose.yml" \
       down --volumes
+
     # Stop and remove nginx-proxy and (if required) docker-gen
     for cid in $(docker ps -a --filter "label=com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite" --format "{{.ID}}"); do
       docker stop "$cid"
       docker rm --volumes "$cid"
     done
+
     # Cleanup files created by the setup
     if [[ -n "${TRAVIS_BUILD_DIR// }" ]]; then
       [[ -f "${TRAVIS_BUILD_DIR}/nginx.tmpl" ]]&& rm "${TRAVIS_BUILD_DIR}/nginx.tmpl"
@@ -92,16 +100,23 @@ EOF
       echo "The ${TRAVIS_BUILD_DIR}/go folder require superuser permission to fully remove."
       echo "Doing sudo rm -rf in scripts is dangerous, so the folder won't be automatically removed."
     fi
+
     # Remove custom entries to /etc/hosts
     echo "Removing custom entries from /etc/hosts (requires sudo)."
     for domain in "${domains[@]}"; do
-      sudo sed --in-place "/127\.0\.0\.1 $domain # le-companion test suite/d" /etc/hosts
+      if [[ "$(uname)" == 'Darwin' ]]; then
+        sudo sed -i '' "/127\.0\.0\.1 $domain # le-companion test suite/d" /etc/hosts
+      else
+        sudo sed --in-place "/127\.0\.0\.1 $domain # le-companion test suite/d" /etc/hosts
+      fi
     done
     ;;
+
     *)
     echo "Usage:"
     echo ""
     echo "    --setup : setup the test suite."
     echo "    --teardown : remove the test suite containers, configuration and files."
     echo ""
+    ;;
 esac


### PR DESCRIPTION
This PR enable local testing on macOS by taking into account minor differences with `sed`, `getopt` and `bash` versions packaged with this OS.

I had to reverted `10.77.77.1` to `localhost` in `test/setup/setup-boulder.sh`, as using the Docker gateway IP to curl Boulder's ACME endpoint from macOS Terminal does not appear to work.