### PR TITLE
Prevent non-Letsencrypt certs removing

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -90,6 +90,11 @@ function cleanup_links {
     # Return 1 if nothing was removed and 0 otherwise.
     if [[ ${#DISABLED_DOMAINS[@]} -gt 0 ]]; then
       for disabled_domain in "${DISABLED_DOMAINS[@]}"; do
+          certfile="${disabled_domain}.crt"
+          # If certificate is not letsencrypt, don't ever try to remove it
+          if [[ -f "${certfile}" ]] && [[ -z $(openssl x509 -noout -issuer -in ${certfile} | grep "Let's Encrypt") ]]; then
+              continue
+          fi;
           for extension in .crt .key .dhparam.pem .chain.pem; do
               file="${disabled_domain}${extension}"
               if [[ -n "${file// }" ]] && [[ -L "/etc/nginx/certs/${file}" ]]; then


### PR DESCRIPTION
In addition to https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/pull/352, I would suggest to keep untouched symlinks to disabled domains, if the certificate does not belong to Letsencrypt.

As a use case example, say I have many `example.com` subdomains and a wildcard certificate `wild.example.com.crt` under `example.com` directory. So I do:

```bash
ln -s example.com/wild.example.com.crt subdomain.example.com.crt
ln -s example.com/wild.example.com.crt otherdomain.example.com.crt
```

and so on. In this case I would not like to see my symlinks removed because they are not created by this proxy companion.