### PR TITLE
Move the self ID retrieval to /app/functions.sh

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -8,28 +8,6 @@ if [[ -n "${ACME_TOS_HASH:-}" ]]; then
     echo "simp_le now implicitly agree to the ACME CA ToS."
 fi
 
-DOCKER_PROVIDER=${DOCKER_PROVIDER:-docker}
-
-case "${DOCKER_PROVIDER}" in
-ecs|ECS)
-    # AWS ECS. Enabled in /etc/ecs/ecs.config (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)
-    if [[ -n "${ECS_CONTAINER_METADATA_FILE:-}" ]]; then
-      export CONTAINER_ID=$(grep ContainerID "${ECS_CONTAINER_METADATA_FILE}" | sed 's/.*: "\(.*\)",/\1/g')
-    else
-      echo "${DOCKER_PROVIDER} specified as 'ecs' but not available. See: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html"
-      exit 1
-    fi
-    ;;
-*)
-    export CONTAINER_ID=$(sed -nE 's/^.+docker[\/-]([a-f0-9]{64}).*/\1/p' /proc/self/cgroup | head -n 1)
-    ;;
-esac
-
-if [[ -z "$CONTAINER_ID" ]]; then
-    echo "Error: can't get my container ID !" >&2
-    exit 1
-fi
-
 function check_docker_socket {
     if [[ $DOCKER_HOST == unix://* ]]; then
         socket_file=${DOCKER_HOST#unix://}
@@ -43,7 +21,7 @@ function check_docker_socket {
 
 function check_writable_directory {
     local dir="$1"
-    docker_api "/containers/$CONTAINER_ID/json" | jq ".Mounts[].Destination" | grep -q "^\"$dir\"$"
+    docker_api "/containers/$(get_self_id)/json" | jq ".Mounts[].Destination" | grep -q "^\"$dir\"$"
     if [[ $? -ne 0 ]]; then
         echo "Warning: '$dir' does not appear to be a mounted volume."
     fi
@@ -81,6 +59,10 @@ source /app/functions.sh
 
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_docker_socket
+    if [[ -z "$(get_self_id)" ]]; then
+        echo "Error: can't get my container ID !" >&2
+        exit 1
+    fi
     if [[ -z "$(get_nginx_proxy_container)" ]]; then
         echo "Error: can't get nginx-proxy container ID !" >&2
         echo "Check that you are doing one of the following :" >&2

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -21,7 +21,7 @@ function check_docker_socket {
 
 function check_writable_directory {
     local dir="$1"
-    docker_api "/containers/$(get_self_id)/json" | jq ".Mounts[].Destination" | grep -q "^\"$dir\"$"
+    docker_api "/containers/${SELF_CID:-$(get_self_cid)}/json" | jq ".Mounts[].Destination" | grep -q "^\"$dir\"$"
     if [[ $? -ne 0 ]]; then
         echo "Warning: '$dir' does not appear to be a mounted volume."
     fi
@@ -59,9 +59,11 @@ source /app/functions.sh
 
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_docker_socket
-    if [[ -z "$(get_self_id)" ]]; then
+    if [[ -z "$(get_self_cid)" ]]; then
         echo "Error: can't get my container ID !" >&2
         exit 1
+    else
+        export SELF_CID="$(get_self_cid)"
     fi
     if [[ -z "$(get_nginx_proxy_container)" ]]; then
         echo "Error: can't get nginx-proxy container ID !" >&2

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -41,6 +41,25 @@ function remove_all_location_configurations {
     eval "$old_shopt_options" # Restore shopt options
 }
 
+function get_self_id {
+    DOCKER_PROVIDER=${DOCKER_PROVIDER:-docker}
+
+    case "${DOCKER_PROVIDER}" in
+    ecs|ECS)
+        # AWS ECS. Enabled in /etc/ecs/ecs.config (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)
+        if [[ -n "${ECS_CONTAINER_METADATA_FILE:-}" ]]; then
+            grep ContainerID "${ECS_CONTAINER_METADATA_FILE}" | sed 's/.*: "\(.*\)",/\1/g'
+        else
+            echo "${DOCKER_PROVIDER} specified as 'ecs' but not available. See: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html" >&2
+            exit 1
+        fi
+        ;;
+    *)
+        sed -nE 's/^.+docker[\/-]([a-f0-9]{64}).*/\1/p' /proc/self/cgroup | head -n 1
+        ;;
+    esac
+}
+
 ## Docker API
 function docker_api {
     local scheme
@@ -121,7 +140,7 @@ function get_nginx_proxy_container {
             nginx_cid="$NGINX_PROXY_CONTAINER"
         # ... else try to get the container ID with the volumes_from method.
         else
-            volumes_from=$(docker_api "/containers/$CONTAINER_ID/json" | jq -r '.HostConfig.VolumesFrom[]' 2>/dev/null)
+            volumes_from=$(docker_api "/containers/$(get_self_id)/json" | jq -r '.HostConfig.VolumesFrom[]' 2>/dev/null)
             for cid in $volumes_from; do
                 cid="${cid%:*}" # Remove leading :ro or :rw set by remote docker-compose (thx anoopr)
                 if [[ $(docker_api "/containers/$cid/json" | jq -r '.Config.Env[]' | egrep -c '^NGINX_VERSION=') = "1" ]];then

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -41,7 +41,7 @@ function remove_all_location_configurations {
     eval "$old_shopt_options" # Restore shopt options
 }
 
-function get_self_id {
+function get_self_cid {
     DOCKER_PROVIDER=${DOCKER_PROVIDER:-docker}
 
     case "${DOCKER_PROVIDER}" in
@@ -140,7 +140,7 @@ function get_nginx_proxy_container {
             nginx_cid="$NGINX_PROXY_CONTAINER"
         # ... else try to get the container ID with the volumes_from method.
         else
-            volumes_from=$(docker_api "/containers/$(get_self_id)/json" | jq -r '.HostConfig.VolumesFrom[]' 2>/dev/null)
+            volumes_from=$(docker_api "/containers/${SELF_CID:-$(get_self_cid)}/json" | jq -r '.HostConfig.VolumesFrom[]' 2>/dev/null)
             for cid in $volumes_from; do
                 cid="${cid%:*}" # Remove leading :ro or :rw set by remote docker-compose (thx anoopr)
                 if [[ $(docker_api "/containers/$cid/json" | jq -r '.Config.Env[]' | egrep -c '^NGINX_VERSION=') = "1" ]];then


### PR DESCRIPTION
This is a fix for #375

This PR move the self ID retrieval to a reusable function, instead of a one time operation that stores the ID in an environment variable at container startup.

The `/app/force_renew` script  being used through `docker exec`, it can't access this environment variable and therefore fails to check for a running nginx container (#321) when using the `--volumes-from` method.