### PR TITLE
Update simp_le to 0.8.0

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -6,7 +6,7 @@ set -e
 apk --update add python py-setuptools git gcc py-pip musl-dev libffi-dev python-dev openssl-dev
 
 # Get Let's Encrypt simp_le client source
-branch="0.7.0"
+branch="0.8.0"
 mkdir -p /src
 git -C /src clone --depth=1 --branch $branch https://github.com/zenhack/simp_le.git
 


### PR DESCRIPTION
`simp_le` version bump.

Nothing groundbreaking in this version other than fixing the deprecation warning reported in #370