### PR TITLE
Fix and extend the docker_api test unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ vhost.d/
 go/
 nginx.tmpl
 test/local_test_env.sh
-test/tests/docker_api/expected_std_out.txt
+test/tests/docker_api/expected-std-out.txt

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -31,7 +31,6 @@ case $SETUP in
       --volumes-from $NGINX_CONTAINER_NAME \
       -v ${TRAVIS_BUILD_DIR}/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro \
       -v /var/run/docker.sock:/tmp/docker.sock:ro \
-      --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen \
       --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
       jwilder/docker-gen \
       -notify-sighup $NGINX_CONTAINER_NAME -watch -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
@@ -43,6 +42,10 @@ case $SETUP in
 
 esac
 
-docker run --name helper --volumes-from $NGINX_CONTAINER_NAME busybox true
+docker run \
+  --name helper \
+  --volumes-from $NGINX_CONTAINER_NAME \
+  --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+  busybox true
 docker cp ${TRAVIS_BUILD_DIR}/test/setup/dhparam.pem helper:/etc/nginx/certs
 docker rm -f helper

--- a/test/tests/docker_api/run.sh
+++ b/test/tests/docker_api/run.sh
@@ -2,94 +2,267 @@
 
 ## Test for the Docker API.
 
-nginx_labeled_container_name='nginx-proxy-label'
-docker_gen_unlabeled_container_name='nginx-proxy-gen-nolabel'
+nginx_vol='nginx-volumes-from'
+nginx_env='nginx-env-var'
+nginx_lbl='nginx-label'
+docker_gen='docker-gen-no-label'
+docker_gen_lbl='docker-gen-label'
 
 case $SETUP in
 
   2containers)
-  cat > ${TRAVIS_BUILD_DIR}/test/tests/docker_api/expected_std_out.txt <<EOF
-Container $NGINX_CONTAINER_NAME received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
-Container $nginx_labeled_container_name received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
-EOF
-
   # Listen to Docker exec_start events
   docker events \
     --filter event=exec_start \
     --format 'Container {{.Actor.Attributes.name}} received {{.Action}}' &
   docker_events_pid=$!
 
-  # Spawn a nginx-proxy container with the nginx_proxy label
-  # The setup already spawned a container without the label
+  # Run a nginx-proxy container named nginx-volumes-from, without the nginx_proxy label
   docker run --rm -d \
-    --name "$nginx_labeled_container_name" \
+    --name "$nginx_vol" \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
     jwilder/nginx-proxy > /dev/null
 
-  # This should exec into the nginx-proxy container without the label (nginx-proxy)
-  docker run --rm \
-    -v /var/run/docker.sock:/var/run/docker.sock:ro \
-    -e "NGINX_PROXY_CONTAINER=$NGINX_CONTAINER_NAME" \
-    "$1" \
-    bash -c 'source /app/functions.sh && reload_nginx' > /dev/null
+  # Run a nginx-proxy container named nginx-env-var, without the nginx_proxy label
+  docker run --rm -d \
+    --name "$nginx_env" \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    jwilder/nginx-proxy > /dev/null
 
-  # This should should exec into the nginx-proxy container with the label (nginx-proxy-label)
+  # This should target the nginx-proxy container obtained with
+  # the --volume-from argument (nginx-volumes-from)
   docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
     "$1" \
-    bash -c 'source /app/functions.sh && reload_nginx' > /dev/null
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_nginx_proxy_container' 2>&1
+
+  # This should target the nginx-proxy container obtained with
+  # the NGINX_PROXY_CONTAINER environment variable (nginx-env-var)
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_nginx_proxy_container' 2>&1
+
+  # Run a nginx-proxy container named nginx-label, with the nginx_proxy label.
+  # Store the container id in the labeled_nginx_cid variable.
+  labeled_nginx_cid="$(docker run --rm -d \
+    --name "$nginx_lbl" \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
+    jwilder/nginx-proxy)"
+
+  # This should target the nginx-proxy container with the label (nginx-label)
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_nginx_proxy_container' 2>&1
 
   # Cleanup
   kill $docker_events_pid && wait $docker_events_pid 2>/dev/null
-  docker stop "$nginx_labeled_container_name" > /dev/null
+  docker stop \
+    "$nginx_vol" \
+    "$nginx_env" \
+    "$nginx_lbl" \
+    > /dev/null
+
+  cat > ${TRAVIS_BUILD_DIR}/test/tests/docker_api/expected-std-out.txt <<EOF
+Container $nginx_vol received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+$nginx_vol
+Container $nginx_env received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+$nginx_env
+Container $nginx_lbl received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+$labeled_nginx_cid
+EOF
   ;;
 
   3containers)
-  cat > ${TRAVIS_BUILD_DIR}/test/tests/docker_api/expected_std_out.txt <<EOF
-Container $docker_gen_unlabeled_container_name received signal 1
-Container $NGINX_CONTAINER_NAME received signal 1
-Container $DOCKER_GEN_CONTAINER_NAME received signal 1
-Container $nginx_labeled_container_name received signal 1
-EOF
-
   # Listen to Docker kill events
   docker events \
     --filter event=kill \
     --format 'Container {{.Actor.Attributes.name}} received signal {{.Actor.Attributes.signal}}' &
   docker_events_pid=$!
 
-  # Spawn a nginx container with the nginx_proxy label
-  # The setup already spawned a container without the label
+  # Run a nginx container named nginx-volumes-from, without the nginx_proxy label.
   docker run --rm -d \
-    --name "$nginx_labeled_container_name" \
+    --name "$nginx_vol" \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    nginx:alpine > /dev/null
+
+  # Run a nginx container named nginx-env-var, without the nginx_proxy label.
+  docker run --rm -d \
+    --name "$nginx_env" \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    nginx:alpine > /dev/null
+
+  # Spawn a "fake docker-gen" container named docker-gen-nolabel, without the docker_gen label.
+  docker run --rm -d \
+    --name "$docker_gen" \
+    nginx:alpine > /dev/null
+
+  # This should target the nginx container whose id or name was obtained with
+  # the --volumes-from argument (nginx-volumes-from)
+  # and the docker-gen container whose id or name was obtained with
+  # the NGINX_DOCKER_GEN_CONTAINER environment variable (docker-gen-nolabel).
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
+
+  # This should target the nginx container whose id or name was obtained with
+  # the NGINX_PROXY_CONTAINER environment variable (nginx-env-var)
+  # and the docker-gen container whose id or name was obtained with
+  # the NGINX_DOCKER_GEN_CONTAINER environment variable (docker-gen-nolabel)
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
+
+  # Spawn a nginx container named nginx-label, with the nginx_proxy label.
+  labeled_nginx1_cid="$(docker run --rm -d \
+    --name "$nginx_lbl" \
     --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
-    nginx:alpine > /dev/null
+    nginx:alpine)"
 
-  # Spawn a fake docker-gen container without the docker-gen label
-  # The setup already spawned a container with the label
-  docker run --rm -d \
-    --name "$docker_gen_unlabeled_container_name" \
-    nginx:alpine > /dev/null
-
-  # This should send SIGHUP to the non labeled docker-gen and nginx (nginx-proxy-gen-nolabel and nginx-proxy)
+  # This should target the nginx container whose id or name was obtained with
+  # the nginx_proxy label (nginx-label)
+  # and the docker-gen container whose id or name was obtained with
+  # the NGINX_DOCKER_GEN_CONTAINER environment variable (docker-gen-nolabel)
   docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
-    -e "NGINX_PROXY_CONTAINER=$NGINX_CONTAINER_NAME" \
-    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen_unlabeled_container_name" \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
     "$1" \
-    bash -c 'source /app/functions.sh && reload_nginx' > /dev/null
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
 
-  # This should send SIGHUP to the labeled docker-gen and nginx (nginx-proxy-gen and nginx-proxy-label)
+  docker stop "$nginx_lbl" > /dev/null
+
+  # Spawn a "fake docker-gen" container named docker-gen-label, with the docker_gen label.
+  labeled_docker_gen_cid="$(docker run --rm -d \
+    --name "$docker_gen_lbl" \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen \
+    nginx:alpine)"
+
+  # This should target the nginx container whose id or name was obtained with
+  # the --volumes-from argument (nginx-volumes-from)
+  # and the docker-gen container whose id or name was obtained with
+  # the docker_gen label (docker-gen-label)
   docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
     "$1" \
-    bash -c 'source /app/functions.sh && reload_nginx' > /dev/null
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
+
+  # This should target the nginx container whose id or name was obtained with
+  # the NGINX_PROXY_CONTAINER environment variable (nginx-env-var)
+  # and the docker-gen container whose id or name was obtained with
+  # the docker_gen label (docker-gen-label)
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
+
+  # Spawn a nginx container named nginx-label, with the nginx_proxy label.
+  labeled_nginx2_cid="$(docker run --rm -d \
+    --name "$nginx_lbl" \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
+    nginx:alpine)"
+
+  # This should target the nginx container whose id or name was obtained with
+  # the nginx_proxy label (nginx-label)
+  # and the docker-gen container whose id or name was obtained with
+  # the docker_gen label (docker-gen-label)
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volumes-from "$nginx_vol" \
+    -e "NGINX_PROXY_CONTAINER=$nginx_env" \
+    -e "NGINX_DOCKER_GEN_CONTAINER=$docker_gen" \
+    "$1" \
+    bash -c 'source /app/functions.sh; \
+            reload_nginx > /dev/null; \
+            check_nginx_proxy_container_run; \
+            get_docker_gen_container; \
+            get_nginx_proxy_container;' 2>&1
 
   # Cleanup
   kill $docker_events_pid && wait $docker_events_pid 2>/dev/null
   docker stop \
-    "$nginx_labeled_container_name" \
-    "$docker_gen_unlabeled_container_name" > /dev/null
+    "$nginx_vol" \
+    "$nginx_env" \
+    "$nginx_lbl" \
+    "$docker_gen" \
+    "$docker_gen_lbl" > /dev/null 2>&1
+
+    cat > ${TRAVIS_BUILD_DIR}/test/tests/docker_api/expected-std-out.txt <<EOF
+Container $docker_gen received signal 1
+Container $nginx_vol received signal 1
+$docker_gen
+$nginx_vol
+Container $docker_gen received signal 1
+Container $nginx_env received signal 1
+$docker_gen
+$nginx_env
+Container $docker_gen received signal 1
+Container $nginx_lbl received signal 1
+$docker_gen
+$labeled_nginx1_cid
+Container $nginx_lbl received signal 15
+Container $docker_gen_lbl received signal 1
+Container $nginx_vol received signal 1
+$labeled_docker_gen_cid
+$nginx_vol
+Container $docker_gen_lbl received signal 1
+Container $nginx_env received signal 1
+$labeled_docker_gen_cid
+$nginx_env
+Container $docker_gen_lbl received signal 1
+Container $nginx_lbl received signal 1
+$labeled_docker_gen_cid
+$labeled_nginx2_cid
+EOF
   ;;
+
 esac

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -12,10 +12,16 @@ export -f get_base_domain
 function run_le_container {
   local image="${1:?}"
   local name="${2:?}"
+  if [[ "$SETUP" == '3containers' ]]; then
+    docker_gen_arg="--env NGINX_DOCKER_GEN_CONTAINER=$DOCKER_GEN_CONTAINER_NAME"
+  else
+    docker_gen_arg=""
+  fi
   docker run -d \
     --name "$name" \
     --volumes-from $NGINX_CONTAINER_NAME \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+    $docker_gen_arg \
     --env "DEBUG=true" \
     --env "ACME_CA_URI=http://${BOULDER_IP}:4000/directory" \
     --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \


### PR DESCRIPTION
Due to a misspelling of `expected-std-out.txt`, the existing test script was actually testing pretty much nothing.

The test has been extended to cover the nine possible mix of `--volumes-from`, environment variables and docker labels.