### PR TITLE
Check for unsupported ACME v2 LE endpoints

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -58,6 +58,12 @@ source /app/functions.sh
 [[ $DEBUG == true ]] && set -x
 
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
+    acmev2_re='https://acme-.*v02\.api\.letsencrypt\.org/directory'
+    if [[ "${ACME_CA_URI:-}" =~ $acmev2_re ]]; then
+        echo "Error: ACME v2 API is not yet supported by simp_le."
+        echo "See https://github.com/zenhack/simp_le/issues/101"
+        exit 1
+    fi
     check_docker_socket
     if [[ -z "$(get_self_cid)" ]]; then
         echo "Error: can't get my container ID !" >&2


### PR DESCRIPTION
As proposed here https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/319#issuecomment-384178784, this adds an explicit error during initialisation if `ACME_CA_URI` is an unsupported -by `simp_le`- Let's Encrypt ACME v2 endpoint.