### PR TITLE
Use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,27 @@
+FROM golang:1.10-alpine AS go-builder
+
+ENV DOCKER_GEN_VERSION=0.7.4
+
+# Install build dependencies for docker-gen
+RUN apk add --update \
+        curl \
+        gcc \
+        git \
+        make \
+        musl-dev
+
+# Build docker-gen
+RUN go get github.com/jwilder/docker-gen \
+    && cd /go/src/github.com/jwilder/docker-gen \
+    && git checkout $DOCKER_GEN_VERSION \
+    && make get-deps \
+    && make all
+
 FROM alpine:3.7
 
 LABEL maintainer="Yves Blusseau <90z7oey02@sneakemail.com> (@blusseau)"
 
 ENV DEBUG=false \
-    DOCKER_GEN_VERSION=0.7.4 \
     DOCKER_HOST=unix:///var/run/docker.sock
 
 # Install packages required by the image
@@ -15,13 +33,15 @@ RUN apk add --update \
         openssl \
     && rm /var/cache/apk/*
 
-# Install docker-gen
-RUN curl -L https://github.com/jwilder/docker-gen/releases/download/${DOCKER_GEN_VERSION}/docker-gen-linux-amd64-${DOCKER_GEN_VERSION}.tar.gz \
-    | tar -C /usr/local/bin -xz
+# Install docker-gen from build stage
+COPY --from=go-builder /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
 
 # Install simp_le
 COPY /install_simp_le.sh /app/install_simp_le.sh
-RUN chmod +rx /app/install_simp_le.sh && sync && /app/install_simp_le.sh && rm -f /app/install_simp_le.sh
+RUN chmod +rx /app/install_simp_le.sh \
+    && sync \
+    && /app/install_simp_le.sh \
+    && rm -f /app/install_simp_le.sh
 
 COPY /app/ /app/
 


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/multistage-build/

This Dockerfile does not fetch a pre built binary of `docker-gen` like the current one but compile it from source during the first stage, then grab the compiled binary for the final image from this stage.

This allows to build the image on any arch the `golang` and `alpine` images are available for from a single Dockerfile.

Tested and working on `arm` 32 bits arch (Raspbian running on  a Raspberry Pi 3).

I feel this is a cleaner and more flexible solution than the usual method of maintaining a different Dockerfile for each arch (as proposed in #372). The drawbacks are:

- requires Docker 17.05+ to build
- the intermediate stage containers have to be manually cleaned