### PR TITLE
Check deprecated env var at container init only

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -3,10 +3,12 @@
 
 set -u
 
-if [[ -n "${ACME_TOS_HASH:-}" ]]; then
-    echo "Info: the ACME_TOS_HASH environment variable is no longer used by simp_le and has been deprecated."
-    echo "simp_le now implicitly agree to the ACME CA ToS."
-fi
+function check_deprecated_env_var {
+    if [[ -n "${ACME_TOS_HASH:-}" ]]; then
+        echo "Info: the ACME_TOS_HASH environment variable is no longer used by simp_le and has been deprecated."
+        echo "simp_le now implicitly agree to the ACME CA ToS."
+    fi
+}
 
 function check_docker_socket {
     if [[ $DOCKER_HOST == unix://* ]]; then
@@ -88,6 +90,7 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_writable_directory '/etc/nginx/certs'
     check_writable_directory '/etc/nginx/vhost.d'
     check_writable_directory '/usr/share/nginx/html'
+    check_deprecated_env_var
     check_dh_group
 fi
 


### PR DESCRIPTION
Like the other `entrypoint.sh` checks, this one is only wanted once, during container initialization.