### PR TITLE
Error message enhancement to #321

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -10,12 +10,17 @@
 
 function check_nginx_proxy_container_run {
     local _nginx_proxy_container=$(get_nginx_proxy_container)
-    if [[ $(docker_api "/containers/${_nginx_proxy_container}/json" | jq -r '.State.Status') = "running" ]];then
-        return 0
-    fi
-
-    echo "$(date "+%Y/%m/%d %T"), Error: nginx-proxy container ${_nginx_proxy_container}  isn't running." >&2
-    return 1
+    if [[ -n "$_nginx_proxy_container" ]]; then
+        if [[ $(docker_api "/containers/${_nginx_proxy_container}/json" | jq -r '.State.Status') = "running" ]];then
+            return 0
+        else
+            echo "$(date "+%Y/%m/%d %T") Error: nginx-proxy container ${_nginx_proxy_container} isn't running." >&2
+            return 1
+        fi
+    else
+        echo "$(date "+%Y/%m/%d %T") Error: could not get a nginx-proxy container ID." >&2
+        return 1
+fi
 }
 
 function add_location_configuration {


### PR DESCRIPTION
Output a different message when the `check_nginx_proxy_container_run` function can't get any container ID, rather than than a message with no container ID.