### PR TITLE
invoke /app/docker-entrypoint.sh when reloading nginx-proxy

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -179,7 +179,7 @@ function reload_nginx {
         if [[ -n "${_nginx_proxy_container:-}" ]]; then
             echo "Reloading nginx proxy (${_nginx_proxy_container})..."
             docker_exec "${_nginx_proxy_container}" \
-                        '[ "sh", "-c", "/usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload" ]'
+                        '[ "sh", "-c", "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload" ]'
             [[ $? -eq 1 ]] && echo "$(date "+%Y/%m/%d %T"), Error: can't reload nginx-proxy." >&2
         fi
     fi

--- a/test/tests/docker_api/run.sh
+++ b/test/tests/docker_api/run.sh
@@ -80,11 +80,11 @@ case $SETUP in
     > /dev/null
 
   cat > ${TRAVIS_BUILD_DIR}/test/tests/docker_api/expected-std-out.txt <<EOF
-Container $nginx_vol received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+Container $nginx_vol received exec_start: sh -c /app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
 $nginx_vol
-Container $nginx_env received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+Container $nginx_env received exec_start: sh -c /app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
 $nginx_env
-Container $nginx_lbl received exec_start: sh -c /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
+Container $nginx_lbl received exec_start: sh -c /app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
 $labeled_nginx_cid
 EOF
   ;;


### PR DESCRIPTION
The /app/docker-entrypoint.sh within nginx-proxy [sets the RESOLVERS environment variable](https://github.com/jwilder/nginx-proxy/blob/master/docker-entrypoint.sh#L22), so when docker-proxy is invoked without it the resolvers aren't set in the nginx config.

The more general problem, which this PR doesn't fix, is that all other environment variables are also clobbered when the config is generated by these means.
Unfortunately, as docker-gen is run via forego within docker-proxy, a HUP signal sent to the docker-proxy container won't be passed through (it just kills the container). I think the actual fix here is probably to change the handling of HUP's within forego?

Might also be worth a note in the README as it took me ages to work out why this environment variable seemed not to be set sometimes...