### PR TITLE
Silence docker_exec noisy output after #401

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -179,8 +179,9 @@ function reload_nginx {
         if [[ -n "${_nginx_proxy_container:-}" ]]; then
             echo "Reloading nginx proxy (${_nginx_proxy_container})..."
             docker_exec "${_nginx_proxy_container}" \
-                        '[ "sh", "-c", "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload" ]'
-            [[ $? -eq 1 ]] && echo "$(date "+%Y/%m/%d %T"), Error: can't reload nginx-proxy." >&2
+                '[ "sh", "-c", "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload" ]' \
+                | sed -rn 's/^.*([0-9]{4}\/[0-9]{2}\/[0-9]{2}.*$)/\1/p'
+            [[ ${PIPESTATUS[0]} -eq 1 ]] && echo "$(date "+%Y/%m/%d %T"), Error: can't reload nginx-proxy." >&2
         fi
     fi
 }


### PR DESCRIPTION
Going through /app/docker-entrypoint.sh in the nginx-proxy container generate some unwanted garbage to std out:

```
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 2Custom dhparam.pem file found, generation skipped
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | h2018/06/14 16:03:18 Contents of /etc/nginx/conf.d/default.conf did not change. Skipping notification ''
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
nginx-proxy-le | 
```

Nothing useful here, so this PR just sends the output of `docker_exec` to `/dev/null`.