### PR TITLE
Remove set -x for debug

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -93,8 +93,6 @@ is being created."
 
 source /app/functions.sh
 
-[[ $DEBUG == true ]] && set -x
-
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     acmev2_re='https://acme-.*v02\.api\.letsencrypt\.org/directory'
     if [[ "${ACME_CA_URI:-}" =~ $acmev2_re ]]; then


### PR DESCRIPTION
In my opinion `set -x` makes the logs quite unreadable and is not of much help when trying to troubleshoot an issue. I'd rather remove it and work on cleaner and clearer debug logging.