### PR TITLE
Disable example.com notification emails

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -144,7 +144,7 @@ function update_certs {
 
         email_varname="LETSENCRYPT_${cid}_EMAIL"
         email_address="${!email_varname}"
-        if [[ "$email_address" != "<no value>" ]]; then
+        if [[ "$email_address" != "<no value>" ]] || [[ $email_address == *@example.com ]]; then
             params_d_str+=" --email $email_address"
         fi
 


### PR DESCRIPTION
Let's encrypt now consider `example.com` emails invalid. This is a breaking change as lot's of people were using it before as a dummy.
This PR makes sure that we don't try to use `example.com` as a notification email.

Note that https://tools.ietf.org/html/rfc2606 also define that `example.com` should be only used in example and not as a dummy.