### PR TITLE
Only consider links in cleanup_links function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,10 @@ script:
 after_failure:
   - docker logs $NGINX_CONTAINER_NAME
   - docker logs docker_api
+  - docker logs default_cert
   - docker logs certs_single
   - docker logs certs_san
+  - docker logs force_renew
   - docker logs symlinks
   - docker logs boulder
   - if [[ $SETUP = "3containers" ]]; then docker logs $DOCKER_GEN_CONTAINER_NAME; fi

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -115,8 +115,7 @@ function check_default_cert_key {
             -keyout /etc/nginx/certs/default.key.new \
             -out /etc/nginx/certs/default.crt.new \
         && mv /etc/nginx/certs/default.key.new /etc/nginx/certs/default.key \
-        && mv /etc/nginx/certs/default.crt.new /etc/nginx/certs/default.crt \
-        && reload_nginx
+        && mv /etc/nginx/certs/default.crt.new /etc/nginx/certs/default.crt
         echo "Info: a default key and certificate have been created at /etc/nginx/certs/default.key and /etc/nginx/certs/default.crt."
     elif [[ $DEBUG == true && "${default_cert_cn:-}" =~ $cn ]]; then
         echo "Debug: the self generated default certificate is still valid for more than three months. Skipping default certificate creation."
@@ -161,6 +160,7 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_deprecated_env_var
     check_default_cert_key
     check_dh_group
+    reload_nginx
 fi
 
 exec "$@"

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -52,7 +52,7 @@ function cleanup_links {
     # Create an array containing domains for which a
     # symlinked private key exists in /etc/nginx/certs.
     for symlinked_domain in /etc/nginx/certs/*.crt; do
-        [[ -f "$symlinked_domain" ]] || continue
+        [[ -L "$symlinked_domain" ]] || continue
         symlinked_domain="${symlinked_domain##*/}"
         symlinked_domain="${symlinked_domain%*.crt}"
         SYMLINKED_DOMAINS+=("$symlinked_domain")


### PR DESCRIPTION
Only add actual links to the `SYMLINKED_DOMAINS` array instead of adding every file matching `/etc/nginx/certs/*.crt`