### PR TITLE
Ci tests cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ script:
 
 after_failure:
   - docker logs $NGINX_CONTAINER_NAME
-  - docker logs docker_api
   - docker logs default_cert
   - docker logs certs_single
   - docker logs certs_san

--- a/test/tests/default_cert/run.sh
+++ b/test/tests/default_cert/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Test for single domain certificates.
+## Test for default certificate creation.
 
 if [[ -z $TRAVIS_CI ]]; then
   le_container_name="$(basename ${0%/*})_$(date "+%Y-%m-%d_%H.%M.%S")"

--- a/test/tests/default_cert/run.sh
+++ b/test/tests/default_cert/run.sh
@@ -15,7 +15,7 @@ IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
 # Cleanup function with EXIT trap
 function cleanup {
   # Cleanup the files created by this run of the test to avoid foiling following test(s).
-  docker exec "$le_container_name" sh -c 'rm -rf /etc/nginx/certs/default.*'
+  docker exec "$le_container_name" bash -c 'rm -f /etc/nginx/certs/default.*'
   docker stop "$le_container_name" > /dev/null
 }
 trap cleanup EXIT
@@ -63,7 +63,7 @@ done
 
 # Test if the default certificate get re-created when
 # the certificate expire in less than three months
-docker exec "$le_container_name" sh -c 'rm -rf /etc/nginx/certs/default.*'
+docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/default.*'
 docker exec "$le_container_name" openssl req -x509 \
   -newkey rsa:4096 -sha256 -nodes -days 60 \
   -subj "/CN=letsencrypt-nginx-proxy-companion" \
@@ -82,7 +82,7 @@ while [[ "$(default_cert_fingerprint)" == "$old_default_cert_fingerprint" ]]; do
 done
 
 # Test that a user provided default certificate isn't overwrited
-docker exec "$le_container_name" sh -c 'rm -rf /etc/nginx/certs/default.*'
+docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/default.*'
 docker exec "$le_container_name" openssl req -x509 \
   -newkey rsa:4096 -sha256 -nodes -days 60 \
   -subj "/CN=$user_cn" \

--- a/test/tests/force_renew/run.sh
+++ b/test/tests/force_renew/run.sh
@@ -12,6 +12,17 @@ run_le_container ${1:?} "$le_container_name"
 # Create the $domains array from comma separated domains in TEST_DOMAINS.
 IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
 
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove the Nginx container silently.
+  docker rm --force "${domains[0]}" > /dev/null 2>&1
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
 # Run a nginx container for ${domains[0]}.
 docker run --rm -d \
   --name "${domains[0]}" \
@@ -39,10 +50,3 @@ else
   echo "First certificate expiration epoch : $first_cert_expire."
   echo "Second certificate expiration epoch : $second_cert_expire."
 fi
-
-# Stop the Nginx container silently.
-docker stop "${domains[0]}" > /dev/null
-
-# Cleanup the files created by this run of the test to avoid foiling following test(s).
-docker exec "$le_container_name" sh -c 'rm -rf /etc/nginx/certs/le?.wtf*'
-docker stop "$le_container_name" > /dev/null


### PR DESCRIPTION
This PR adds trapped cleanup functions to the test units, mostly useful when running the tests manually (without them, a lot of stuff have to be manually cleaned if a test stall and has to be killed).

+ fixes for a few typos / minor errors