### PR TITLE
Ownership and permissions configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ after_failure:
   - docker logs certs_single
   - docker logs certs_san
   - docker logs force_renew
-  - docker logs permissions
+  - docker logs permissions_default
+  - docker logs permissions_custom
   - docker logs symlinks
   - docker logs boulder
   - if [[ $SETUP = "3containers" ]]; then docker logs $DOCKER_GEN_CONTAINER_NAME; fi

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -115,14 +115,14 @@ function check_default_cert_key {
             -keyout /etc/nginx/certs/default.key.new \
             -out /etc/nginx/certs/default.crt.new \
         && mv /etc/nginx/certs/default.key.new /etc/nginx/certs/default.key \
-        && mv /etc/nginx/certs/default.crt.new /etc/nginx/certs/default.crt \
-        && set_root_ownership_and_permissions /etc/nginx/certs/default.key
+        && mv /etc/nginx/certs/default.crt.new /etc/nginx/certs/default.crt
         echo "Info: a default key and certificate have been created at /etc/nginx/certs/default.key and /etc/nginx/certs/default.crt."
     elif [[ $DEBUG == true && "${default_cert_cn:-}" =~ $cn ]]; then
         echo "Debug: the self generated default certificate is still valid for more than three months. Skipping default certificate creation."
     elif [[ $DEBUG == true ]]; then
         echo "Debug: the default certificate is user provided. Skipping default certificate creation."
     fi
+    set_ownership_and_permissions "/etc/nginx/certs/default.key"
 }
 
 source /app/functions.sh

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -201,11 +201,11 @@ function reload_nginx {
 
 function set_ownership_and_permissions {
   local path="${1:?}"
-  # The default ownership is root:root, with 700 permissions for folders and 600 for files.
+  # The default ownership is root:root, with 755 permissions for folders and 644 for files.
   local user="${FILES_UID:-root}"
   local group="${FILES_GID:-$user}"
-  local f_perms="${FILES_PERMS:-600}"
-  local d_perms="${FOLDERS_PERMS:-700}"
+  local f_perms="${FILES_PERMS:-644}"
+  local d_perms="${FOLDERS_PERMS:-755}"
 
   if [[ ! "$f_perms" =~ ^[0-7]{3,4}$ ]]; then
     echo "Warning : the provided files permission octal ($f_perms) is incorrect. Skipping ownership and permissions check."

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -243,9 +243,14 @@ function set_ownership_and_permissions {
   fi
 
   # Check and modify ownership if required.
-  if [[ "$(stat -c %u:%g "$path" )" != "$user_num:$group_num" ]]; then
-    [[ $DEBUG == true ]] && echo "Debug: setting $path ownership to $user:$group."
-    chown "$user_num:$group_num" "$path"
+  if [[ -e "$path" ]]; then
+    if [[ "$(stat -c %u:%g "$path" )" != "$user_num:$group_num" ]]; then
+      [[ $DEBUG == true ]] && echo "Debug: setting $path ownership to $user:$group."
+      chown "$user_num:$group_num" "$path"
+    fi
+  else
+    [[ $DEBUG == true ]] && echo "Debug: $path does not exist. Skipping ownership and permissions check."
+    return 1
   fi
 
   # Check and modify permissions if required.

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -253,16 +253,26 @@ function set_ownership_and_permissions {
     return 1
   fi
 
-  # Check and modify permissions if required.
+  # If the path is a folder, check and modify permissions if required.
   if [[ -d "$path" ]]; then
     if [[ "$(stat -c %a "$path")" != "$d_perms" ]]; then
       [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $d_perms."
       chmod "$d_perms" "$path"
     fi
-  elif [[ -f "$path" ]]; then
-    if [[ "$(stat -c %a "$path")" != "$f_perms" ]]; then
-      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $f_perms."
-      chmod "$f_perms" "$path"
+  # If the path is a file, check and modify permissions if required.
+elif [[ -f "$path" ]]; then
+    # Use different permissions for private files (private keys and ACME account keys) ...
+    if [[ "$path" =~ ^.*(default\.key|key\.pem|\.json)$ ]]; then
+      if [[ "$(stat -c %a "$path")" != "$f_perms" ]]; then
+        [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $f_perms."
+        chmod "$f_perms" "$path"
+      fi
+    # ... and for public files (certificates, chains, fullchains, DH parameters).
+    else
+      if [[ "$(stat -c %a "$path")" != "644" ]]; then
+        [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to 644."
+        chmod "$f_perms" "$path"
+      fi
     fi
   fi
 }

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -199,23 +199,65 @@ function reload_nginx {
     fi
 }
 
-function set_root_ownership_and_permissions {
+function set_ownership_and_permissions {
   local path="${1:?}"
+  # The default ownership is root:root, with 700 permissions for folders and 600 for files.
+  local user="${FILES_UID:-root}"
+  local group="${FILES_GID:-$user}"
+  local f_perms="${FILES_PERMS:-600}"
+  local d_perms="${FOLDERS_PERMS:-700}"
 
-  if [[ $(stat -c %U:%G "$path" ) != root:root ]]; then
-    chown root:root "$path"
-    [[ $DEBUG == true ]] && echo "Debug: setting $path ownership to root:root."
+  if [[ ! "$f_perms" =~ ^[0-7]{3,4}$ ]]; then
+    echo "Warning : the provided files permission octal ($f_perms) is incorrect. Skipping ownership and permissions check."
+    return 1
+  fi
+  if [[ ! "$d_perms" =~ ^[0-7]{3,4}$ ]]; then
+    echo "Warning : the provided folders permission octal ($d_perms) is incorrect. Skipping ownership and permissions check."
+    return 1
   fi
 
+  # Find the user numeric ID if the FILES_UID environment variable isn't numeric.
+  if [[ "$user" =~ ^[0-9]+$ ]]; then
+    user_num="$user"
+  # Check if this user exist inside the container
+  elif id -u "$user" > /dev/null 2>&1; then
+    # Convert the user name to numeric ID
+    local user_num="$(id -u "$user")"
+    [[ $DEBUG == true ]] && echo "Debug: numeric ID of user $user is $user_num."
+  else
+    echo "Warning: user $user not found in the container, please use a numeric user ID instead of a user name. Skipping ownership and permissions check."
+    return 1
+  fi
+
+  # Find the group numeric ID if the FILES_GID environment variable isn't numeric.
+  if [[ "$group" =~ ^[0-9]+$ ]]; then
+    group_num="$group"
+  # Check if this group exist inside the container
+  elif getent group "$group" > /dev/null 2>&1; then
+    # Convert the group name to numeric ID
+    local group_num="$(getent group "$group" | awk -F ':' '{print $3}')"
+    [[ $DEBUG == true ]] && echo "Debug: numeric ID of group $group is $group_num."
+  else
+    echo "Warning: group $group not found in the container, please use a numeric group ID instead of a group name. Skipping ownership and permissions check."
+    return 1
+  fi
+
+  # Check and modify ownership if required.
+  if [[ "$(stat -c %u:%g "$path" )" != "$user_num:$group_num" ]]; then
+    [[ $DEBUG == true ]] && echo "Debug: setting $path ownership to $user:$group."
+    chown "$user_num:$group_num" "$path"
+  fi
+
+  # Check and modify permissions if required.
   if [[ -d "$path" ]]; then
-    if [[ $(stat -c %a "$path") != 700 ]]; then
-      chmod 700 "$path"
-      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to 700."
+    if [[ "$(stat -c %a "$path")" != "$d_perms" ]]; then
+      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $d_perms."
+      chmod "$d_perms" "$path"
     fi
   elif [[ -f "$path" ]]; then
-    if [[ $(stat -c %a "$path") != 600 ]]; then
-      chmod 600 "$path"
-      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to 600."
+    if [[ "$(stat -c %a "$path")" != "$f_perms" ]]; then
+      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $f_perms."
+      chmod "$f_perms" "$path"
     fi
   fi
 }

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -249,7 +249,7 @@ function set_ownership_and_permissions {
       chown "$user_num:$group_num" "$path"
     fi
   else
-    [[ $DEBUG == true ]] && echo "Debug: $path does not exist. Skipping ownership and permissions check."
+    echo "Warning: $path does not exist. Skipping ownership and permissions check."
     return 1
   fi
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -181,7 +181,7 @@ function update_certs {
         # Create directory for the first domain,
         # make it root readable only and make it the cwd
         mkdir -p "$certificate_dir"
-        set_root_ownership_and_permissions "$certificate_dir"
+        set_ownership_and_permissions "$certificate_dir"
         pushd "$certificate_dir" || return
 
         for domain in "${!hosts_array}"; do
@@ -233,7 +233,7 @@ function update_certs {
         # /etc/nginx/certs/accounts included) root readable only
         account_key_perm_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}.json"
         until [[ "$account_key_perm_path" == /etc/nginx/certs ]]; do
-          set_root_ownership_and_permissions "$account_key_perm_path"
+          set_ownership_and_permissions "$account_key_perm_path"
           account_key_perm_path="$(dirname "$account_key_perm_path")"
         done
 
@@ -246,7 +246,7 @@ function update_certs {
             fi
           done
           # Make private key root readable only
-          set_root_ownership_and_permissions "${certificate_dir}/key.pem"
+          set_ownership_and_permissions "${certificate_dir}/key.pem"
           # Queue nginx reload if a certificate was issued or renewed
           [[ $simp_le_return -eq 0 ]] && should_reload_nginx='true'
         fi

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -238,7 +238,9 @@ function update_certs {
             fi
           done
           # Make private key root readable only
-          set_ownership_and_permissions "${certificate_dir}/key.pem"
+          for filename in cert key chain fullchain; do
+            set_ownership_and_permissions "${certificate_dir}/${filename}.pem"
+          done
           # Make the account key and its parent folders (up to
           # /etc/nginx/certs/accounts included) root readable only
           account_key_perm_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}.json"

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -229,14 +229,6 @@ function update_certs {
 
         popd || return
 
-        # Make the account key and its parent folders (up to
-        # /etc/nginx/certs/accounts included) root readable only
-        account_key_perm_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}.json"
-        until [[ "$account_key_perm_path" == /etc/nginx/certs ]]; do
-          set_ownership_and_permissions "$account_key_perm_path"
-          account_key_perm_path="$(dirname "$account_key_perm_path")"
-        done
-
         if [[ $simp_le_return -ne 2 ]]; then
           for domain in "${!hosts_array}"; do
             if [[ "$acme_ca_uri" == "$le_staging_uri" ]]; then
@@ -247,6 +239,13 @@ function update_certs {
           done
           # Make private key root readable only
           set_ownership_and_permissions "${certificate_dir}/key.pem"
+          # Make the account key and its parent folders (up to
+          # /etc/nginx/certs/accounts included) root readable only
+          account_key_perm_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}.json"
+          until [[ "$account_key_perm_path" == /etc/nginx/certs ]]; do
+            set_ownership_and_permissions "$account_key_perm_path"
+            account_key_perm_path="$(dirname "$account_key_perm_path")"
+          done
           # Queue nginx reload if a certificate was issued or renewed
           [[ $simp_le_return -eq 0 ]] && should_reload_nginx='true'
         fi

--- a/test/config.sh
+++ b/test/config.sh
@@ -12,7 +12,8 @@ imageTests+=(
 	certs_single
 	certs_san
 	force_renew
-	permissions
+	permissions_default
+	permissions_custom
 	symlinks
 	'
 )

--- a/test/tests/permissions/run.sh
+++ b/test/tests/permissions/run.sh
@@ -44,7 +44,7 @@ folders=( \
 # Test folder paths
 for folder in  "${folders[@]}"; do
   ownership_and_permissions="$(docker exec "$le_container_name" stat -c %U:%G:%a "$folder")"
-  [[ "$ownership_and_permissions" == root:root:700 ]] || echo "Expected root:root:700 on ${folder}, found ${ownership_and_permissions}."
+  [[ "$ownership_and_permissions" == root:root:755 ]] || echo "Expected root:root:755 on ${folder}, found ${ownership_and_permissions}."
 done
 
 # Array of file paths to test
@@ -57,5 +57,5 @@ files=( \
 # Test file paths
 for file in  "${files[@]}"; do
   ownership_and_permissions="$(docker exec "$le_container_name" stat -c %U:%G:%a "$file")"
-  [[ "$ownership_and_permissions" == root:root:600 ]] || echo "Expected root:root:600 on ${file}, found ${ownership_and_permissions}."
+  [[ "$ownership_and_permissions" == root:root:644 ]] || echo "Expected root:root:644 on ${file}, found ${ownership_and_permissions}."
 done

--- a/test/tests/permissions_custom/expected-std-out.txt
+++ b/test/tests/permissions_custom/expected-std-out.txt
@@ -1,0 +1,4 @@
+Started letsencrypt container for test permissions_custom
+Started test web server for le1.wtf
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem

--- a/test/tests/permissions_custom/run.sh
+++ b/test/tests/permissions_custom/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+## Test for sensitive files and folders permissions
+
+if [[ -z $TRAVIS_CI ]]; then
+  le_container_name="$(basename ${0%/*})_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename ${0%/*})"
+fi
+run_le_container ${1:?} "$le_container_name" \
+  "--env FILES_UID=1000 --env FILES_GID=1001 --env FILES_PERMS=640 --env FOLDERS_PERMS=750"
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove the ${domains[0]} Nginx container silently.
+  docker rm --force "${domains[0]}" > /dev/null 2>&1
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
+# Run an nginx container for ${domains[0]}.
+docker run --rm -d \
+  --name "${domains[0]}" \
+  -e "VIRTUAL_HOST=${domains[0]}" \
+  -e "LETSENCRYPT_HOST=${domains[0]}" \
+  nginx:alpine > /dev/null && echo "Started test web server for ${domains[0]}"
+
+# Wait for the cert symlink.
+wait_for_symlink "${domains[0]}" "$le_container_name"
+
+# Array of folder paths to test
+folders=( \
+  [0]="/etc/nginx/certs/accounts" \
+  [1]="/etc/nginx/certs/accounts/boulder:4000" \
+  [2]="/etc/nginx/certs/accounts/boulder:4000/directory" \
+  [3]="/etc/nginx/certs/${domains[0]}" \
+  )
+
+# Test folder paths
+for folder in  "${folders[@]}"; do
+  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$folder")"
+  [[ "$ownership_and_permissions" == 1000:1001:750 ]] || echo "Expected 1000:1001:750 on ${folder}, found ${ownership_and_permissions}."
+done
+
+# Array of file paths to test
+files=( \
+  [0]="/etc/nginx/certs/default.key" \
+  [1]="/etc/nginx/certs/accounts/boulder:4000/directory/default.json" \
+  [2]="/etc/nginx/certs/${domains[0]}/key.pem" \
+  )
+
+# Test file paths
+for file in  "${files[@]}"; do
+  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$file")"
+  [[ "$ownership_and_permissions" == 1000:1001:640 ]] || echo "Expected 1000:1001:640 on ${file}, found ${ownership_and_permissions}."
+done

--- a/test/tests/permissions_default/expected-std-out.txt
+++ b/test/tests/permissions_default/expected-std-out.txt
@@ -1,4 +1,4 @@
-Started letsencrypt container for test permissions
+Started letsencrypt container for test permissions_default
 Started test web server for le1.wtf
 Symlink to le1.wtf certificate has been generated.
 The link is pointing to the file ./le1.wtf/fullchain.pem

--- a/test/tests/permissions_default/run.sh
+++ b/test/tests/permissions_default/run.sh
@@ -43,8 +43,8 @@ folders=( \
 
 # Test folder paths
 for folder in  "${folders[@]}"; do
-  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %U:%G:%a "$folder")"
-  [[ "$ownership_and_permissions" == root:root:755 ]] || echo "Expected root:root:755 on ${folder}, found ${ownership_and_permissions}."
+  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$folder")"
+  [[ "$ownership_and_permissions" == 0:0:755 ]] || echo "Expected 0:0:755 on ${folder}, found ${ownership_and_permissions}."
 done
 
 # Array of file paths to test
@@ -56,6 +56,25 @@ files=( \
 
 # Test file paths
 for file in  "${files[@]}"; do
-  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %U:%G:%a "$file")"
-  [[ "$ownership_and_permissions" == root:root:644 ]] || echo "Expected root:root:644 on ${file}, found ${ownership_and_permissions}."
+  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$file")"
+  if [[ "$ownership_and_permissions" != 0:0:644 ]]; then
+    echo "Expected 0:0:644 on ${file}, found ${ownership_and_permissions}."
+  fi
+done
+
+# Array of public files paths to test
+public_files=( \
+  [0]="/etc/nginx/certs/${domains[0]}/cert.pem" \
+  [1]="/etc/nginx/certs/${domains[0]}/chain.pem" \
+  [2]="/etc/nginx/certs/${domains[0]}/fullchain.pem" \
+  [3]="/etc/nginx/certs/default.crt" \
+  [4]="/etc/nginx/certs/dhparam.pem" \
+  )
+
+# Test public file paths
+for file in  "${public_files[@]}"; do
+  ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$file")"
+  if [[ "$ownership_and_permissions" != 0:0:644 ]]; then
+    echo "Expected 0:0:644 on ${file}, found ${ownership_and_permissions}."
+  fi
 done

--- a/test/tests/permissions_default/run.sh
+++ b/test/tests/permissions_default/run.sh
@@ -44,18 +44,20 @@ folders=( \
 # Test folder paths
 for folder in  "${folders[@]}"; do
   ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$folder")"
-  [[ "$ownership_and_permissions" == 0:0:755 ]] || echo "Expected 0:0:755 on ${folder}, found ${ownership_and_permissions}."
+  if [[ "$ownership_and_permissions" != 0:0:755 ]]; then
+    echo "Expected 0:0:755 on ${folder}, found ${ownership_and_permissions}."
+  fi
 done
 
-# Array of file paths to test
-files=( \
+# Array of private file paths to test
+private_files=( \
   [0]="/etc/nginx/certs/default.key" \
   [1]="/etc/nginx/certs/accounts/boulder:4000/directory/default.json" \
   [2]="/etc/nginx/certs/${domains[0]}/key.pem" \
   )
 
-# Test file paths
-for file in  "${files[@]}"; do
+# Test private file paths
+for file in  "${private_files[@]}"; do
   ownership_and_permissions="$(docker exec "$le_container_name" stat -c %u:%g:%a "$file")"
   if [[ "$ownership_and_permissions" != 0:0:644 ]]; then
     echo "Expected 0:0:644 on ${file}, found ${ownership_and_permissions}."

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -13,16 +13,15 @@ export -f get_base_domain
 function run_le_container {
   local image="${1:?}"
   local name="${2:?}"
+  local cli_args="${3:-}"
   if [[ "$SETUP" == '3containers' ]]; then
-    docker_gen_arg="--env NGINX_DOCKER_GEN_CONTAINER=$DOCKER_GEN_CONTAINER_NAME"
-  else
-    docker_gen_arg=""
+    cli_args+=" --env NGINX_DOCKER_GEN_CONTAINER=$DOCKER_GEN_CONTAINER_NAME"
   fi
   docker run -d \
     --name "$name" \
     --volumes-from $NGINX_CONTAINER_NAME \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-    $docker_gen_arg \
+    $cli_args \
     --env "DHPARAM_BITS=256" \
     --env "DEBUG=true" \
     --env "ACME_CA_URI=http://boulder:4000/directory" \


### PR DESCRIPTION
This PR introduces the following environment variables to provide control over ownership and permissions of the certificates and keys created by the container (+ the related Travis tests) :

* `FILES_UID` - Set the user owning the files and folders managed by the container. The variable can be either a user name if this user exists inside the container or a user numeric ID. Default to `root` (user ID `0`).
* `FILES_GID` - Set the group owning the files and folders managed by the container. The variable can be either a group name if this group exists inside the container or a group numeric ID. Default to the same value as `FILES_UID`.
* `FILES_PERMS` - Set the permissions of the private keys and ACME account keys. The variable must be a valid octal permission setting and defaults to `644`.
* `FOLDERS_PERMS` - Set the permissions of the folders managed by the container. The variable must be a valid octal permission setting and defaults to `755`.

This reverse the default behaviour as it was before #436. I'm still not sure if we should go for secure (ie restraining read access on sensitive files) as default or maintain the previous behaviour to avoid breaking existing workflows based upon the rather lax permissions.

This will close #412 and #461 once merged.