### PR TITLE
Follow certificates managed by the companion with a dot file

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -88,31 +88,26 @@ function cleanup_links {
     # Remove disabled domains symlinks if present.
     # Return 1 if nothing was removed and 0 otherwise.
     if [[ ${#DISABLED_DOMAINS[@]} -gt 0 ]]; then
-      [[ $DEBUG == true ]] && echo "Some domains are disabled. Check them to remove unused symlinks."
+      [[ $DEBUG == true ]] && echo "Some domains are disabled :"
       for disabled_domain in "${DISABLED_DOMAINS[@]}"; do
-          [[ $DEBUG == true ]] && echo -e -n "\nChecking domain ${disabled_domain}: "
-          certfile="/etc/nginx/certs/${disabled_domain}.crt"
-          # If certificate is not letsencrypt, don't ever try to remove it
-          if [[ -f "${certfile}" ]]; then
-              issuer="$(openssl x509 -noout -issuer -in ${certfile})"
-              le_regex="Let's Encrypt"
-              ci_regex="h[a,2]ppy h[a,2]cker fake CA"
-              if [[ ! "$issuer" =~ $le_regex ]] && [[ ! "$issuer" =~ $ci_regex ]]; then
-                  [[ $DEBUG == true ]] && echo "certificate is not LE. Skipping."
-                  continue
-              fi
+          [[ $DEBUG == true ]] && echo "Checking domain ${disabled_domain}"
+          cert_folder="$(readlink -f /etc/nginx/certs/${disabled_domain}.crt)"
+          # If the dotfile is absent, skip domain.
+          if [[ ! -e "${cert_folder%/*}/.companion" ]]; then
+              [[ $DEBUG == true ]] && echo "No .companion file found in ${cert_folder}. ${disabled_domain} is not managed by letsencrypt-nginx-proxy-companion. Skipping domain."
+              continue
+          else
+              [[ $DEBUG == true ]] && echo "${disabled_domain} is managed by letsencrypt-nginx-proxy-companion. Removing unused symlinks."
           fi
 
           for extension in .crt .key .dhparam.pem .chain.pem; do
               file="${disabled_domain}${extension}"
-              [[ $DEBUG == true ]] && echo -n -e "\nChecking ${file}"
               if [[ -n "${file// }" ]] && [[ -L "/etc/nginx/certs/${file}" ]]; then
-                  [[ $DEBUG == true ]] && echo -n " - removing."
+                  [[ $DEBUG == true ]] && echo "Removing /etc/nginx/certs/${file}"
                   rm -f "/etc/nginx/certs/${file}"
               fi
           done
       done
-      [[ $DEBUG == true ]] && echo -e "\nUnused domains checking is finished."
       return 0
     else
       return 1
@@ -236,6 +231,8 @@ function update_certs {
             else
               create_links "$base_domain" "$domain" && should_reload_nginx='true'
             fi
+            touch "${certificate_dir}/.companion"
+            set_ownership_and_permissions "${certificate_dir}/.companion"
           done
           # Make private key root readable only
           for filename in cert key chain fullchain; do

--- a/test/tests/symlinks/expected-std-out.txt
+++ b/test/tests/symlinks/expected-std-out.txt
@@ -20,6 +20,6 @@ Started test web server for le2.wtf
 Symlink to le2.wtf certificate has been generated.
 The link is pointing to the file ./le2.wtf/fullchain.pem
 Started test web server for lim.it,le2.wtf
-Symlink for lim.it certificate was not generated under three minutes, timing out.
+Symlink for lim.it certificate was not generated under one minute, timing out.
 Symlink to le2.wtf certificate has been generated.
 The link is pointing to the file ./le2.wtf/fullchain.pem

--- a/test/tests/symlinks/run.sh
+++ b/test/tests/symlinks/run.sh
@@ -52,8 +52,11 @@ for domain in "${domains[@]}"; do
 done
 
 # Create a fake le4.wtf custom certificate and key
-docker exec "$le_container_name" cp /etc/nginx/certs/le1.wtf/fullchain.pem /etc/nginx/certs/le4.wtf.crt
-docker exec "$le_container_name" cp /etc/nginx/certs/le1.wtf/key.pem /etc/nginx/certs/le4.wtf.key
+docker exec "$le_container_name" mkdir -p /etc/nginx/certs/le4.wtf
+docker exec "$le_container_name" cp /etc/nginx/certs/le1.wtf/fullchain.pem /etc/nginx/certs/le4.wtf/
+docker exec "$le_container_name" cp /etc/nginx/certs/le1.wtf/key.pem /etc/nginx/certs/le4.wtf/
+docker exec "$le_container_name" ln -s /etc/nginx/certs/le4.wtf/fullchain.pem /etc/nginx/certs/le4.wtf.crt
+docker exec "$le_container_name" ln -s /etc/nginx/certs/le4.wtf/key.pem /etc/nginx/certs/le4.wtf.key
 
 # Stop the nginx containers for ${domains[0]} and ${domains[1]} silently,
 # then check if the corresponding symlinks are removed.

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -53,14 +53,14 @@ function wait_for_symlink {
 export -f wait_for_symlink
 
 
-# Wait for the /etc/nginx/certs/$1.crt file to be removed inside container $2
+# Wait for the /etc/nginx/certs/$1.crt symlink to be removed inside container $2
 function wait_for_symlink_rm {
   local domain="${1:?}"
   local name="${2:?}"
   local i=0
-  until docker exec "$name" [ ! -f "/etc/nginx/certs/$domain.crt" ]; do
     if [ $i -gt 120 ]; then
       echo "Certificate symlink for $domain was not removed under two minutes, timing out."
+  until docker exec "$name" [ ! -L "/etc/nginx/certs/$domain.crt" ]; do
       return 1
     fi
     i=$((i + 2))

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -39,8 +39,8 @@ function wait_for_symlink {
   local i=0
   local target
   until docker exec "$name" [ -L "/etc/nginx/certs/$domain.crt" ]; do
-    if [ $i -gt 180 ]; then
-      echo "Symlink for $domain certificate was not generated under three minutes, timing out."
+    if [ $i -gt 60 ]; then
+      echo "Symlink for $domain certificate was not generated under one minute, timing out."
       return 1
     fi
     i=$((i + 2))
@@ -58,9 +58,9 @@ function wait_for_symlink_rm {
   local domain="${1:?}"
   local name="${2:?}"
   local i=0
-    if [ $i -gt 120 ]; then
-      echo "Certificate symlink for $domain was not removed under two minutes, timing out."
   until docker exec "$name" [ ! -L "/etc/nginx/certs/$domain.crt" ]; do
+    if [ $i -gt 60 ]; then
+      echo "Certificate symlink for $domain was not removed under one minute, timing out."
       return 1
     fi
     i=$((i + 2))


### PR DESCRIPTION
As discussed in #465, this PR should fix the remaining issues with hybrid configurations (certs obtained through the companion stored and used along certs obtained another way).

> [...] include a dot file next to the certs handled by the companion during creation / renewal (most importantly before the symlink cleanup function). Then the symlink cleanup function check for the presence of this dot file. If it's not there, those files are not handled by the companion, don't touch the symlinks.

@ejbp any thought before merging this ?