### PR TITLE
Make the DEBUG env var case insensitive

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -103,7 +103,7 @@ function check_default_cert_key {
         # than 3 months / 7776000 seconds (60 x 60 x 24 x 30 x 3).
         check_cert_min_validity /etc/nginx/certs/default.crt 7776000
         cert_validity=$?
-        [[ $DEBUG == true ]] && echo "Debug: a default certificate with $default_cert_cn is present."
+        [[ "$(lc $DEBUG)" == true ]] && echo "Debug: a default certificate with $default_cert_cn is present."
     fi
 
     # Create a default cert and private key if:
@@ -120,9 +120,9 @@ function check_default_cert_key {
         && mv /etc/nginx/certs/default.key.new /etc/nginx/certs/default.key \
         && mv /etc/nginx/certs/default.crt.new /etc/nginx/certs/default.crt
         echo "Info: a default key and certificate have been created at /etc/nginx/certs/default.key and /etc/nginx/certs/default.crt."
-    elif [[ $DEBUG == true && "${default_cert_cn:-}" =~ $cn ]]; then
+    elif [[ "$(lc $DEBUG)" == true && "${default_cert_cn:-}" =~ $cn ]]; then
         echo "Debug: the self generated default certificate is still valid for more than three months. Skipping default certificate creation."
-    elif [[ $DEBUG == true ]]; then
+    elif [[ "$(lc $DEBUG)" == true ]]; then
         echo "Debug: the default certificate is user provided. Skipping default certificate creation."
     fi
     set_ownership_and_permissions "/etc/nginx/certs/default.key"

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -223,7 +223,7 @@ function set_ownership_and_permissions {
   elif id -u "$user" > /dev/null 2>&1; then
     # Convert the user name to numeric ID
     local user_num="$(id -u "$user")"
-    [[ $DEBUG == true ]] && echo "Debug: numeric ID of user $user is $user_num."
+    [[ "$(lc $DEBUG)" == true ]] && echo "Debug: numeric ID of user $user is $user_num."
   else
     echo "Warning: user $user not found in the container, please use a numeric user ID instead of a user name. Skipping ownership and permissions check."
     return 1
@@ -236,7 +236,7 @@ function set_ownership_and_permissions {
   elif getent group "$group" > /dev/null 2>&1; then
     # Convert the group name to numeric ID
     local group_num="$(getent group "$group" | awk -F ':' '{print $3}')"
-    [[ $DEBUG == true ]] && echo "Debug: numeric ID of group $group is $group_num."
+    [[ "$(lc $DEBUG)" == true ]] && echo "Debug: numeric ID of group $group is $group_num."
   else
     echo "Warning: group $group not found in the container, please use a numeric group ID instead of a group name. Skipping ownership and permissions check."
     return 1
@@ -245,7 +245,7 @@ function set_ownership_and_permissions {
   # Check and modify ownership if required.
   if [[ -e "$path" ]]; then
     if [[ "$(stat -c %u:%g "$path" )" != "$user_num:$group_num" ]]; then
-      [[ $DEBUG == true ]] && echo "Debug: setting $path ownership to $user:$group."
+      [[ "$(lc $DEBUG)" == true ]] && echo "Debug: setting $path ownership to $user:$group."
       chown "$user_num:$group_num" "$path"
     fi
   else
@@ -256,7 +256,7 @@ function set_ownership_and_permissions {
   # If the path is a folder, check and modify permissions if required.
   if [[ -d "$path" ]]; then
     if [[ "$(stat -c %a "$path")" != "$d_perms" ]]; then
-      [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $d_perms."
+      [[ "$(lc $DEBUG)" == true ]] && echo "Debug: setting $path permissions to $d_perms."
       chmod "$d_perms" "$path"
     fi
   # If the path is a file, check and modify permissions if required.
@@ -264,13 +264,13 @@ elif [[ -f "$path" ]]; then
     # Use different permissions for private files (private keys and ACME account keys) ...
     if [[ "$path" =~ ^.*(default\.key|key\.pem|\.json)$ ]]; then
       if [[ "$(stat -c %a "$path")" != "$f_perms" ]]; then
-        [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to $f_perms."
+        [[ "$(lc $DEBUG)" == true ]] && echo "Debug: setting $path permissions to $f_perms."
         chmod "$f_perms" "$path"
       fi
     # ... and for public files (certificates, chains, fullchains, DH parameters).
     else
       if [[ "$(stat -c %a "$path")" != "644" ]]; then
-        [[ $DEBUG == true ]] && echo "Debug: setting $path permissions to 644."
+        [[ "$(lc $DEBUG)" == true ]] && echo "Debug: setting $path permissions to 644."
         chmod "$f_perms" "$path"
       fi
     fi

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -13,7 +13,7 @@ function create_link {
     local -r source=${1?missing source argument}
     local -r target=${2?missing target argument}
     if [[ -f "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
-      [[ $DEBUG == true ]] && echo "$target already linked to $source"
+      [[ "$(lc $DEBUG)" == true ]] && echo "$target already linked to $source"
       return 1
     else
       ln -sf "$source" "$target"
@@ -57,7 +57,7 @@ function cleanup_links {
         symlinked_domain="${symlinked_domain%*.crt}"
         SYMLINKED_DOMAINS+=("$symlinked_domain")
     done
-    [[ $DEBUG == true ]] && echo "Symlinked domains: ${SYMLINKED_DOMAINS[*]}"
+    [[ "$(lc $DEBUG)" == true ]] && echo "Symlinked domains: ${SYMLINKED_DOMAINS[*]}"
 
     # Create an array containing domains that are considered
     # enabled (ie present on /app/letsencrypt_service_data).
@@ -71,7 +71,7 @@ function cleanup_links {
         ENABLED_DOMAINS+=("$domain")
       done
     done
-    [[ $DEBUG == true ]] && echo "Enabled domains: ${ENABLED_DOMAINS[*]}"
+    [[ "$(lc $DEBUG)" == true ]] && echo "Enabled domains: ${ENABLED_DOMAINS[*]}"
 
     # Create an array containing only domains for which a symlinked private key exists
     # in /etc/nginx/certs but that no longer have a corresponding LETSENCRYPT_HOST set
@@ -82,28 +82,28 @@ function cleanup_links {
                                              "${ENABLED_DOMAINS[@]}" \
                                              | tr ' ' '\n' | sort | uniq -u)
     fi
-    [[ $DEBUG == true ]] && echo "Disabled domains: ${DISABLED_DOMAINS[*]}"
+    [[ "$(lc $DEBUG)" == true ]] && echo "Disabled domains: ${DISABLED_DOMAINS[*]}"
 
 
     # Remove disabled domains symlinks if present.
     # Return 1 if nothing was removed and 0 otherwise.
     if [[ ${#DISABLED_DOMAINS[@]} -gt 0 ]]; then
-      [[ $DEBUG == true ]] && echo "Some domains are disabled :"
+      [[ "$(lc $DEBUG)" == true ]] && echo "Some domains are disabled :"
       for disabled_domain in "${DISABLED_DOMAINS[@]}"; do
-          [[ $DEBUG == true ]] && echo "Checking domain ${disabled_domain}"
+          [[ "$(lc $DEBUG)" == true ]] && echo "Checking domain ${disabled_domain}"
           cert_folder="$(readlink -f /etc/nginx/certs/${disabled_domain}.crt)"
           # If the dotfile is absent, skip domain.
           if [[ ! -e "${cert_folder%/*}/.companion" ]]; then
-              [[ $DEBUG == true ]] && echo "No .companion file found in ${cert_folder}. ${disabled_domain} is not managed by letsencrypt-nginx-proxy-companion. Skipping domain."
+              [[ "$(lc $DEBUG)" == true ]] && echo "No .companion file found in ${cert_folder}. ${disabled_domain} is not managed by letsencrypt-nginx-proxy-companion. Skipping domain."
               continue
           else
-              [[ $DEBUG == true ]] && echo "${disabled_domain} is managed by letsencrypt-nginx-proxy-companion. Removing unused symlinks."
+              [[ "$(lc $DEBUG)" == true ]] && echo "${disabled_domain} is managed by letsencrypt-nginx-proxy-companion. Removing unused symlinks."
           fi
 
           for extension in .crt .key .dhparam.pem .chain.pem; do
               file="${disabled_domain}${extension}"
               if [[ -n "${file// }" ]] && [[ -L "/etc/nginx/certs/${file}" ]]; then
-                  [[ $DEBUG == true ]] && echo "Removing /etc/nginx/certs/${file}"
+                  [[ "$(lc $DEBUG)" == true ]] && echo "Removing /etc/nginx/certs/${file}"
                   rm -f "/etc/nginx/certs/${file}"
               fi
           done
@@ -169,7 +169,7 @@ function update_certs {
             account_alias=default
         fi
 
-        [[ $DEBUG == true ]] && params_d_str+=" -v"
+        [[ "$(lc $DEBUG)" == true ]] && params_d_str+=" -v"
         [[ $REUSE_PRIVATE_KEYS == true ]] && params_d_str+=" --reuse_key"
         [[ "${1}" == "--force-renew" ]] && params_d_str+=" --valid_min 7776000"
 


### PR DESCRIPTION
The DEBUG env var is actually case sensitive (eg it will work when set to `true` but not to `True` as it should). This PR makes it case insensitive.