### PR TITLE
Change ownership of symlinks in addition to regular files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ENV DEBUG=false \
 RUN apk add --update \
         bash \
         ca-certificates \
+        coreutils \
         curl \
         jq \
         openssl \

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -13,10 +13,12 @@ function create_link {
     local -r source=${1?missing source argument}
     local -r target=${2?missing target argument}
     if [[ -f "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
+      set_ownership_and_permissions "$target"
       [[ "$(lc $DEBUG)" == true ]] && echo "$target already linked to $source"
       return 1
     else
-      ln -sf "$source" "$target"
+      ln -sf "$source" "$target" \
+        && set_ownership_and_permissions "$target"
     fi
 }
 
@@ -194,10 +196,12 @@ function update_certs {
             if [[ -f "$account_key_full_path" ]]; then
                 # If there is no symlink to the account key, create it
                 if [[ ! -L ./account_key.json ]]; then
-                    ln -sf "$account_key_full_path" ./account_key.json
+                    ln -sf "$account_key_full_path" ./account_key.json \
+                      && set_ownership_and_permissions ./account_key.json
                 # If the symlink target the wrong account key, replace it
                 elif [[ "$(readlink -f ./account_key.json)" != "$account_key_full_path" ]]; then
-                    ln -sf "$account_key_full_path" ./account_key.json
+                    ln -sf "$account_key_full_path" ./account_key.json \
+                      && set_ownership_and_permissions ./account_key.json
                 fi
             fi
         fi
@@ -235,8 +239,8 @@ function update_certs {
             set_ownership_and_permissions "${certificate_dir}/.companion"
           done
           # Make private key root readable only
-          for filename in cert key chain fullchain; do
-            set_ownership_and_permissions "${certificate_dir}/${filename}.pem"
+          for file in cert.pem key.pem chain.pem fullchain.pem account_key.json; do
+            set_ownership_and_permissions "${certificate_dir}/${file}"
           done
           # Make the account key and its parent folders (up to
           # /etc/nginx/certs/accounts included) root readable only

--- a/test/tests/permissions_custom/run.sh
+++ b/test/tests/permissions_custom/run.sh
@@ -55,6 +55,23 @@ for folder in  "${folders[@]}"; do
   fi
 done
 
+# Array of symlinks paths to test
+symlinks=( \
+  [0]="/etc/nginx/certs/${domains[0]}.crt" \
+  [1]="/etc/nginx/certs/${domains[0]}.key" \
+  [2]="/etc/nginx/certs/${domains[0]}.chain.pem" \
+  [3]="/etc/nginx/certs/${domains[0]}.dhparam.pem" \
+  [4]="/etc/nginx/certs/${domains[0]}/account_key.json" \
+  )
+
+  # Test symlinks paths
+  for symlink in  "${symlinks[@]}"; do
+    ownership="$(docker exec "$le_container_name" stat -c %u:%g "$symlink")"
+    if [[ "$ownership" != ${files_uid}:${files_gid} ]]; then
+      echo "Expected ${files_uid}:${files_gid} on ${symlink}, found ${ownership}."
+    fi
+  done
+
 # Array of private file paths to test
 private_files=( \
   [0]="/etc/nginx/certs/default.key" \

--- a/test/tests/permissions_default/run.sh
+++ b/test/tests/permissions_default/run.sh
@@ -49,6 +49,23 @@ for folder in  "${folders[@]}"; do
   fi
 done
 
+# Array of symlinks paths to test
+symlinks=( \
+  [0]="/etc/nginx/certs/${domains[0]}.crt" \
+  [1]="/etc/nginx/certs/${domains[0]}.key" \
+  [2]="/etc/nginx/certs/${domains[0]}.chain.pem" \
+  [3]="/etc/nginx/certs/${domains[0]}.dhparam.pem" \
+  [4]="/etc/nginx/certs/${domains[0]}/account_key.json" \
+  )
+
+  # Test symlinks paths
+  for symlink in  "${symlinks[@]}"; do
+    ownership="$(docker exec "$le_container_name" stat -c %u:%g "$symlink")"
+    if [[ "$ownership" != 0:0 ]]; then
+      echo "Expected 0:0 on ${symlink}, found ${ownership}."
+    fi
+  done
+
 # Array of private file paths to test
 private_files=( \
   [0]="/etc/nginx/certs/default.key" \


### PR DESCRIPTION
As brought up by @desimaniac in #471, the recent ownership and permissions configuration option (#463) did not change the symlinks ownership. This PR fix this to avoid confusion.