### PR TITLE
Fix DH parameters overwrite issue

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -87,13 +87,14 @@ is being created."
     # Generate a new dhparam in the background in a low priority and reload nginx when finished (grep removes the progress indicator).
     (
         (
-            nice -n +5 openssl dhparam -out "$DHPARAM_FILE" "$DHPARAM_BITS" 2>&1 \
+            nice -n +5 openssl dhparam -out "${DHPARAM_FILE}.new" "$DHPARAM_BITS" 2>&1 \
+            && mv "${DHPARAM_FILE}.new" "$DHPARAM_FILE" \
             && echo "Info: Diffie-Hellman group creation complete, reloading nginx." \
             && set_ownership_and_permissions "$DHPARAM_FILE" \
             && reload_nginx
         ) | grep -vE '^[\.+]+'
         rm "$GEN_LOCKFILE"
-    ) &disown
+    ) & disown
 }
 
 function check_default_cert_key {


### PR DESCRIPTION
This PR applies the same solution to the same issue as https://github.com/jwilder/nginx-proxy/pull/1213 and fixes #543 

Also `&disown` triggered ShellCheck, [with a suggestion to replace it with `& disown`](https://github.com/koalaman/shellcheck/wiki/SC1132#exceptions).