### PR TITLE
Set auth_request off for acme challenge location

### DIFF
--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,5 +1,6 @@
 location ^~ /.well-known/acme-challenge/ {
     auth_basic off;
+    auth_request off;
     allow all;
     root /usr/share/nginx/html;
     try_files $uri =404;


### PR DESCRIPTION
Issue #569. Simple change to ensure that auth_request is off for the acme challenge location, just as we do for auth_basic.