### PR TITLE
Enable use of wildcard location configurations

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -23,10 +23,61 @@ function check_nginx_proxy_container_run {
 fi
 }
 
+function ascending_wildcard_locations {
+    # Given foo.bar.baz.example.com as argument, will output:
+    # - *.bar.baz.example.com
+    # - *.baz.example.com
+    # - *.example.com
+    local domain="${1:?}"
+    local first_label
+    regex="^[[:alnum:]_\-]+(\.[[:alpha:]]+)?$"
+    until [[ "$domain" =~ $regex ]]; do
+      first_label="${domain%%.*}"
+      domain="${domain/${first_label}./}"
+      echo "*.${domain}"
+    done
+}
+
+function descending_wildcard_locations {
+    # Given foo.bar.baz.example.com as argument, will output:
+    # - foo.bar.baz.example.*
+    # - foo.bar.baz.*
+    # - foo.bar.*
+    # - foo.*
+    local domain="${1:?}"
+    local last_label
+    regex="^[[:alnum:]_\-]+$"
+    until [[ "$domain" =~ $regex ]]; do
+      last_label="${domain##*.}"
+      domain="${domain/.${last_label}/}"
+      echo "${domain}.*"
+    done
+}
+
+function enumerate_wildcard_locations {
+    # Goes through ascending then descending wildcard locations for a given FQDN
+    local domain="${1:?}"
+    ascending_wildcard_locations "$domain"
+    descending_wildcard_locations "$domain"
+}
+
 function add_location_configuration {
     local domain="${1:-}"
-    # If no domain was passed or if the domain has no custom conf, use default instead
-    [[ -z "$domain" || ! -f "${VHOST_DIR}/${domain}" ]] && domain=default
+    local wildcard_domain
+    # If no domain was passed use default instead
+    [[ -z "$domain" ]] && domain='default'
+
+    # If the domain does not have an exact matching location file, test the possible
+    # wildcard locations files. Use default is no location file is present at all.
+    if [[ ! -f "${VHOST_DIR}/${domain}" ]]; then
+      for wildcard_domain in $(enumerate_wildcard_locations "$domain"); do
+        if [[ -f "${VHOST_DIR}/${wildcard_domain}" ]]; then
+          domain="$wildcard_domain"
+          break
+        fi
+        domain='default'
+      done
+    fi
 
     if [[ -f "${VHOST_DIR}/${domain}" && -n $(sed -n "/$START_HEADER/,/$END_HEADER/p" "${VHOST_DIR}/${domain}") ]]; then
         # If the config file exist and already have the location configuration, end with exit code 0

--- a/test/tests/location_config/expected-std-out.txt
+++ b/test/tests/location_config/expected-std-out.txt
@@ -1,1 +1,8 @@
 Started letsencrypt container for test location_config
+*.bar.baz.example.com
+*.baz.example.com
+*.example.com
+foo.bar.baz.example.*
+foo.bar.baz.*
+foo.bar.*
+foo.*


### PR DESCRIPTION
This PR is a fix for #561 

It makes the location configuration work as follow. Let say the domain is `foo.bar.baz.example.tld`:

- if a config file with the exact same name as your domain (`foo.bar.baz.example.tld`) is present, use it.
- else try every corresponding wildcard domain, from most qualified to least qualified, first ascending through the labels to the base domain (`*.bar.baz.example.tld`, `*.baz.example.tld`, `*.example.tld`) then descending (`foo.bar.baz.example.*`, `foor.bar.baz.*`, `foo.bar.*`, `foo.*`). The first matching config file will be used.
- if no wildcard location config file was found either, use the `default` location config file.