### PR TITLE
Verify files existence before perm check

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -282,17 +282,22 @@ function update_certs {
           touch "${certificate_dir}/.companion"
           # Set ownership and permissions of the files inside $certificate_dir
           for file in .companion cert.pem key.pem chain.pem fullchain.pem account_key.json account_reg.json; do
-            set_ownership_and_permissions "${certificate_dir}/${file}"
+            file_path="${certificate_dir}/${file}"
+            [[ -e "$file_path" ]] && set_ownership_and_permissions "$file_path"
           done
-          # Set ownership and permissions of the ACME account key and its parent
-          # folders (up to /etc/nginx/certs/accounts included)
-          account_key_perm_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}_key.json"
-          until [[ "$account_key_perm_path" == /etc/nginx/certs ]]; do
-            set_ownership_and_permissions "$account_key_perm_path"
-            account_key_perm_path="$(dirname "$account_key_perm_path")"
+          account_path="/etc/nginx/certs/accounts/${acme_ca_uri#*://}"
+          account_key_perm_path="${account_path}/${account_alias}_key.json"
+          account_reg_perm_path="${account_path}/${account_alias}_reg.json"
+          # Account key and registration files do not necessarily exists after
+          # simp_le exit code 1. Check if they exist before perm check (#591).
+          [[ -f "$account_key_perm_path" ]] && set_ownership_and_permissions "$account_key_perm_path"
+          [[ -f "$account_reg_perm_path" ]] && set_ownership_and_permissions "$account_reg_perm_path"
+          # Set ownership and permissions of the ACME account folder and its
+          # parent folders (up to /etc/nginx/certs/accounts included)
+          until [[ "$account_path" == /etc/nginx/certs ]]; do
+            set_ownership_and_permissions "$account_path"
+            account_path="$(dirname "$account_path")"
           done
-          # Set ownership and permissions of the ACME account registration
-          set_ownership_and_permissions "/etc/nginx/certs/accounts/${acme_ca_uri#*://}/${account_alias}_reg.json"
           # Queue nginx reload if a certificate was issued or renewed
           [[ $simp_le_return -eq 0 ]] && should_reload_nginx='true' && should_restart_container='true'
         fi


### PR DESCRIPTION
This PR is a fix for #591, needed after the switch from ACME v1 accounts to ACME v2 accounts.