### PR TITLE
Update doc to reflect ACME v2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It handles the automated creation, renewal and use of Let's Encrypt certificates for proxyed Docker containers.
 
-Please note that **letsencrypt-nginx-proxy-companion** no longer supports ACME v1 endpoints. The last tagged version that supports ACME v1 is [v1.11](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/releases/tag/v1.11.2).
+Please note that **letsencrypt-nginx-proxy-companion** no longer supports ACME v1 endpoints. The last tagged version that supports ACME v1 is [v1.11](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/releases/tag/v1.11.2)
 
 ### Features:
 * Automated creation/renewal of Let's Encrypt (or other ACME CAs) certificates using [**simp_le**](https://github.com/zenhack/simp_le).

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -1,8 +1,8 @@
 ## Optional container environment variables for custom configuration.
 
-* `ACME_CA_URI` - Directory URI for the CA ACME API endpoint (defaults to ``https://acme-v01.api.letsencrypt.org/directory``).
+* `ACME_CA_URI` - Directory URI for the CA ACME API endpoint (defaults to ``https://acme-v02.api.letsencrypt.org/directory``).
 
-If you set this environment variable value to `https://acme-staging.api.letsencrypt.org/directory` the container will obtain its certificates from Let's Encrypt test API endpoint that don't have the [5 certs/week/domain limit](https://letsencrypt.org/docs/rate-limits/) (but are not trusted by browsers).
+If you set this environment variable value to `https://acme-staging-v02.api.letsencrypt.org/directory` the container will obtain its certificates from Let's Encrypt test API endpoint that don't have the [5 certs/week/domain limit](https://letsencrypt.org/docs/rate-limits/) (but are not trusted by browsers).
 
 For example
 
@@ -12,14 +12,14 @@ $ docker run --detach \
     --volumes-from nginx-proxy \
     --volume /path/to/certs:/etc/nginx/certs:rw \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-    --env "ACME_CA_URI=https://acme-staging.api.letsencrypt.org/directory" \
+    --env "ACME_CA_URI=https://acme-staging-v02.api.letsencrypt.org/directory" \
     jrcs/letsencrypt-nginx-proxy-companion
 ```
 You can also create test certificates per container (see [Test certificates](./Let's-Encrypt-and-ACME.md#test-certificates))
 
 * `DEBUG` - Set it to `true` to enable debugging output one the container logs, which could help you troubleshoot configuration issues.
 
-* `REUSE_ACCOUNT_KEYS` - Set it to `false` to disable the account keys reutilization (see [ACME account keys](./Let's-Encrypt-and-ACME.md#acme-account-keys)).
+* `REUSE_ACCOUNT_KEYS` - Set it to `false` to disable the account keys and account registrations reutilization (see [ACME account keys](./Let's-Encrypt-and-ACME.md#disable-account-re-utilization)).
 
 * `REUSE_PRIVATE_KEYS` - Set it to `true` to make `simp_le` reuse previously generated private key for each certificate instead of creating a new one on certificate renewal. Recommended if you intend to use [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning) (please not however that HPKP has been deprecated by Google's Chrome and that its use is therefore not recommended).
 

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -59,7 +59,7 @@ The `LETSENCRYPT_RESTART_CONTAINER` environment variable, when set to `true` on 
 
 #### ACME account alias
 
-See the [ACME account keys](#multiple-account-keys-per-endpoint) section.
+See the [ACME account keys](#multiple-accounts-per-endpoint) section.
 
 ### global (set on letsencrypt-nginx-proxy-companion container)
 
@@ -73,22 +73,22 @@ The `REUSE_PRIVATE_KEYS` environment variable, when set to `true` on the **letse
 
 Reusing private keys can help if you intend to use HPKP, but please note that HPKP will be deprecated by at least one major browser (Chrome), and that it is therefore strongly discouraged to use it at all.
 
-#### ACME account key re-utilization
+#### ACME account re-utilization
 
-See the [ACME account keys](#disable-account-keys-re-utilization) section.
+See the [ACME account keys](#disable-account-re-utilization) section.
 
-## ACME account keys
+## ACME account keys and registrations
 
-By default the container will save the first ACME account key created for each ACME API endpoint used, and will reuse it for all subsequent authorization and issuance requests made to this endpoint. This behavior is enabled by default to avoid running into Let's Encrypt account [rate limits](https://letsencrypt.org/docs/rate-limits/).
+By default the container will save the first ACME v2 account key and account registration created for each ACME v2 API endpoint used, and will reuse them for all subsequent authorization and issuance requests made to this endpoint. This behaviour is enabled by default to avoid running into Let's Encrypt account [rate limits](https://letsencrypt.org/docs/rate-limits/).
 
-For instance, when using the default Let's Encrypt production endpoint, the container will save the first account key created for this endpoint as `/etc/nginx/certs/accounts/acme-v01.api.letsencrypt.org/directory/default.json` and will reuse it for future requests made to this endpoint.
+For instance, when using the default Let's Encrypt ACME v2 production endpoint, the container will save the first account key created for this endpoint as `/etc/nginx/certs/accounts/acme-v02.api.letsencrypt.org/directory/default_key.json`, the corresponding account registration as `/etc/nginx/certs/accounts/acme-v02.api.letsencrypt.org/directory/default_reg.json` and will reuse them for future requests made to this endpoint.
 
-#### Multiple account keys per endpoint
+#### Multiple accounts per endpoint
 
-If required, you can use multiple accounts for the same ACME API endpoint by using the `LETSENCRYPT_ACCOUNT_ALIAS` environment variable on your proxyed container. This instruct the **letsencrypt-nginx-proxy-companion** container to look for an account key named after the provided alias instead of `default.json`. For example, `LETSENCRYPT_ACCOUNT_ALIAS=client1` will use the key named `client1.json` in the corresponding ACME API endpoint folder for this proxyed container (or will create it if it does not exists yet).
+If required, you can use multiple accounts for the same ACME v2 API endpoint by using the `LETSENCRYPT_ACCOUNT_ALIAS` environment variable on your proxyed container(s). This instruct the **letsencrypt-nginx-proxy-companion** container to look for an account key and an account registration named after the provided alias instead of `default_key.json` and `default_reg.json`. For example, `LETSENCRYPT_ACCOUNT_ALIAS=client1` will use the key named `client1_key.json` and the registration named `client1_reg.json` in the corresponding ACME API endpoint folder for this proxyed container (or will create them if they do not exist yet).
 
 Please see the *One Account or Many?* paragraph on [Let's Encrypt Integration Guide](https://letsencrypt.org/docs/integration-guide/) for additional information.
 
-#### Disable account keys re-utilization
+#### Disable account re-utilization
 
-If you want to disable the account key re-utilization entirely, you can set the environment variable `REUSE_ACCOUNT_KEYS` to `false` on the **letsencrypt-nginx-proxy-companion** container. This creates a new ACME registration with a corresponding account key for each new certificate issuance. Note that this won't create new account keys for certs already issued before `REUSE_ACCOUNT_KEYS` is set to `false`. This is not recommended unless you have specific reasons to do so.
+If you want to disable the account key and registration re-utilization entirely, you can set the environment variable `REUSE_ACCOUNT_KEYS` to `false` on the **letsencrypt-nginx-proxy-companion** container. This creates a new ACME v2 account key and account registration for each new certificate issuance. Note that this won't create new account keys / registrations for certs already issued before `REUSE_ACCOUNT_KEYS` is set to `false`. This is not recommended unless you have specific reasons to do so.

--- a/docs/Persistent-data.md
+++ b/docs/Persistent-data.md
@@ -70,14 +70,14 @@ By default, the **letsencrypt-nginx-proxy-companion** container will enforce the
 ```
 [drwxr-xr-x]  /etc/nginx/certs
 ├── [drwxr-xr-x root root]  accounts
-│   └── [drwxr-xr-x root root]  acme-v01.api.letsencrypt.org
+│   └── [drwxr-xr-x root root]  acme-v02.api.letsencrypt.org
 │       └── [drwxr-xr-x root root]  directory
 │           └── [-rw-r--r-- root root]  default.json
 ├── [-rw-r--r-- root root]  dhparam.pem
 ├── [-rw-r--r-- root root]  default.crt
 ├── [-rw-r--r-- root root]  default.key
 ├── [drwxr-xr-x root root]  domain.tld
-│   ├── [lrwxrwxrwx root root]  account_key.json -> ../accounts/acme-v01.api.letsencrypt.org/directory/default.json
+│   ├── [lrwxrwxrwx root root]  account_key.json -> ../accounts/acme-v02.api.letsencrypt.org/directory/default.json
 │   ├── [-rw-r--r-- root root]  cert.pem
 │   ├── [-rw-r--r-- root root]  chain.pem
 │   ├── [-rw-r--r-- root root]  fullchain.pem
@@ -100,14 +100,14 @@ For example, `FILES_UID=1000`, `FILES_PERMS=600` and `FOLDERS_PERMS=700` will re
 ```
 [drwxr-xr-x]  /etc/nginx/certs
 ├── [drwx------ 1000 1000]  accounts
-│   └── [drwx------ 1000 1000]  acme-v01.api.letsencrypt.org
+│   └── [drwx------ 1000 1000]  acme-v02.api.letsencrypt.org
 │       └── [drwx------ 1000 1000]  directory
 │           └── [-rw------- 1000 1000]  default.json
 ├── [-rw-r--r-- 1000 1000]  dhparam.pem
 ├── [-rw-r--r-- 1000 1000]  default.crt
 ├── [-rw------- 1000 1000]  default.key
 ├── [drwx------ 1000 1000]  domain.tld
-│   ├── [lrwxrwxrwx 1000 1000]  account_key.json -> ../accounts/acme-v01.api.letsencrypt.org/directory/default.json
+│   ├── [lrwxrwxrwx 1000 1000]  account_key.json -> ../accounts/acme-v02.api.letsencrypt.org/directory/default.json
 │   ├── [-rw-r--r-- 1000 1000]  cert.pem
 │   ├── [-rw-r--r-- 1000 1000]  chain.pem
 │   ├── [-rw-r--r-- 1000 1000]  fullchain.pem
@@ -119,4 +119,3 @@ For example, `FILES_UID=1000`, `FILES_PERMS=600` and `FOLDERS_PERMS=700` will re
 ```
 
 If you just want to make the most sensitive files (private keys and ACME account keys) root readable only, set the environment variable `FILES_PERMS` to `600` on your **letsencrypt-nginx-proxy-companion** container.
-

--- a/docs/Standalone-certificates-(beta).md
+++ b/docs/Standalone-certificates-(beta).md
@@ -63,7 +63,7 @@ Those are all single bash variables.
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
 
-`LETSENCRYPT_uniqueidentifier_ACCOUNT_ALIAS` : see the [ACME account keys documentation](./Let's-Encrypt-and-ACME.md#disable-account-keys-re-utilization).
+`LETSENCRYPT_uniqueidentifier_ACCOUNT_ALIAS` : see the [ACME account documentation](./Let's-Encrypt-and-ACME.md#multiple-accounts-per-endpoint).
 
 ### Picking up changes to letsencrypt_user_data
 


### PR DESCRIPTION
This PR brings the documentation in line with the changes made by the switch from ACME v1 to ACME v2 protocol support.