### PR TITLE
feat: include stopped containers for creation/renewal

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -20,7 +20,11 @@ letsencrypt_service_pid=$!
 
 wait_default="5s:20s"
 DOCKER_GEN_WAIT="${DOCKER_GEN_WAIT:-$wait_default}"
-docker-gen -watch -notify '/app/signal_le_service' -wait "$DOCKER_GEN_WAIT" /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+if parse_true "${INCLUDE_STOPPED:=false}"; then
+  docker-gen -watch -include-stopped -notify '/app/signal_le_service' -wait "$DOCKER_GEN_WAIT" /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+else
+  docker-gen -watch -notify '/app/signal_le_service' -wait "$DOCKER_GEN_WAIT" /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+fi
 docker_gen_pid=$!
 
 # wait "indefinitely"

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -40,3 +40,4 @@ You can also create test certificates per container (see [Test certificates](./L
 
 * `RELOAD_NGINX_ONLY_ONCE` - The companion reload nginx configuration after every new or renewed certificate. Previously this was done only once per service loop, at the end of the loop (this was causing delayed availability of HTTPS enabled application when multiple new certificates where requested at once, see [issue #1147](https://github.com/nginx-proxy/acme-companion/issues/1147)). You can restore the previous behaviour if needed by setting the environment variable `RELOAD_NGINX_ONLY_ONCE` to `true`.
 
+* `INCLUDE_STOPPED` - Whether to include stopped containers when generating certificates. Useful for when the **nginx-proxy** container might need to serve a valid page for offline containers.


### PR DESCRIPTION
The intent here is to start a discussion on the viability of enabling certificate renewal for stopped containers; useful when you might want NGINX proxy to serve an 'unavailable' page or similar with a valid certificate.

Seemingly a simple change, though might need some test cases. Would you be open to including this or something similar?