### PR TITLE
test: bump pebble to 2.10.1

### DIFF
--- a/test/setup/pebble/.env
+++ b/test/setup/pebble/.env
@@ -1,2 +1,2 @@
-PEBBLE_VERSION='2.10.0'
+PEBBLE_VERSION='2.10.1'
 PEBBLE_CONFIG='pebble-config.json'

--- a/test/setup/pebble/setup-pebble.sh
+++ b/test/setup/pebble/setup-pebble.sh
@@ -3,7 +3,7 @@
 set -e
 
 setup_pebble() {
-    curl --silent --show-error https://raw.githubusercontent.com/letsencrypt/pebble/refs/tags/v2.10.0/test/certs/pebble.minica.pem > "${GITHUB_WORKSPACE}/pebble.minica.pem"
+    curl --silent --show-error https://raw.githubusercontent.com/letsencrypt/pebble/refs/tags/v2.10.1/test/certs/pebble.minica.pem > "${GITHUB_WORKSPACE}/pebble.minica.pem"
     cat "${GITHUB_WORKSPACE}/pebble.minica.pem"
     docker compose --file "${GITHUB_WORKSPACE}/test/setup/pebble/compose.yaml" up --detach
 }


### PR DESCRIPTION
Self explanatory

https://github.com/letsencrypt/pebble/releases/tag/v2.10.1